### PR TITLE
Removed unnecessary repetition in Abe::ToLeftRightMovement_44E340()

### DIFF
--- a/Source/AliveLib/Abe.cpp
+++ b/Source/AliveLib/Abe.cpp
@@ -8548,85 +8548,45 @@ __int16 Abe::ToLeftRightMovement_44E340()
     }
 
     const DWORD pressed = sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_0_pressed;
-
     const FP gridSize = ScaleToGridSize_4498B0(field_CC_sprite_scale);
+    const BOOL flipX = field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX);
 
-    if (sInputKey_Right_5550D0 & pressed)
+    if ((flipX && (pressed & sInputKey_Right_5550D0)) || (!flipX && (pressed & sInputKey_Left_5550D4)))
     {
-        if (field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX))
-        {
-            field_106_current_motion = eAbeStates::State_2_StandingTurn_451830;
-            return 1;
-        }
-
-        if (pressed & sInputKey_Run_5550E8)
-        {
-            field_C4_velx = gridSize / FP_FromInteger(4);
-            field_106_current_motion = eAbeStates::State_39_StandingToRun_450D40;
-        }
-        else if (pressed & sInputKey_Sneak_5550EC)
-        {
-            field_C4_velx = gridSize / FP_FromInteger(10);
-            field_106_current_motion = eAbeStates::State_45_SneakBegin_4507A0;
-        }
-        else
-        {
-            field_C4_velx = gridSize / FP_FromInteger(9);
-            field_106_current_motion = eAbeStates::State_6_WalkBegin_44FEE0;
-        }
-
-        if (!WallHit_408750(field_CC_sprite_scale * FP_FromInteger(50), gridSize))
-        {
-            if (!WallHit_408750(field_CC_sprite_scale * FP_FromInteger(20), gridSize))
-            {
-                return 1;
-            }
-        }
-
-        // Walking into wall?
-        if (WallHit_408750(field_CC_sprite_scale * FP_FromInteger(20), gridSize))
-        {
-            PushWall_44E890();
-            return 0;
-        }
-
-        field_106_current_motion = eAbeStates::State_19_StandToCrouch_453DC0;
+        field_106_current_motion = eAbeStates::State_2_StandingTurn_451830;
         return 1;
     }
-    else if (pressed & sInputKey_Left_5550D4)
+
+    if ((pressed & sInputKey_Right_5550D0) || (pressed & sInputKey_Left_5550D4))
     {
-        if (!field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX))
-        {
-            field_106_current_motion = eAbeStates::State_2_StandingTurn_451830;
-            return 1;
-        }
+        const FP directionX = FP_FromInteger((pressed & sInputKey_Right_5550D0) ? 1 : -1);
 
         if (pressed & sInputKey_Run_5550E8)
         {
-            field_C4_velx = -(gridSize / FP_FromInteger(4));
+            field_C4_velx = directionX * (gridSize / FP_FromInteger(4));
             field_106_current_motion = eAbeStates::State_39_StandingToRun_450D40;
         }
         else if (pressed & sInputKey_Sneak_5550EC)
         {
-            field_C4_velx = -(gridSize / FP_FromInteger(10));
+            field_C4_velx = directionX * (gridSize / FP_FromInteger(10));
             field_106_current_motion = eAbeStates::State_45_SneakBegin_4507A0;
         }
         else
         {
-            field_C4_velx = -(gridSize / FP_FromInteger(9));
+            field_C4_velx = directionX * (gridSize / FP_FromInteger(9));
             field_106_current_motion = eAbeStates::State_6_WalkBegin_44FEE0;
         }
 
-        if (!WallHit_408750(field_CC_sprite_scale * FP_FromInteger(50), -gridSize))
+        if (!WallHit_408750(field_CC_sprite_scale * FP_FromInteger(50), directionX * gridSize))
         {
-            if (!WallHit_408750(field_CC_sprite_scale * FP_FromInteger(20), -gridSize))
+            if (!WallHit_408750(field_CC_sprite_scale * FP_FromInteger(20), directionX * gridSize))
             {
                 return 1;
             }
         }
 
         // Walking into wall?
-        if (WallHit_408750(field_CC_sprite_scale * FP_FromInteger(20), -gridSize))
+        if (WallHit_408750(field_CC_sprite_scale * FP_FromInteger(20), directionX * gridSize))
         {
             PushWall_44E890();
             return 0;


### PR DESCRIPTION
Moving Abe left and right repeated same code, making the method "Abe::ToLeftRightMovement_44E340()" unnecessarily long. This version controls the movement direction using an auxiliary variable "directionX", allowing a single code segment to handle both the left and right movements.