### PR TITLE
Fix to the gas timer bug

### DIFF
--- a/Source/AliveLib/GasCountDown.cpp
+++ b/Source/AliveLib/GasCountDown.cpp
@@ -81,6 +81,11 @@ GasCountDown* GasCountDown::ctor_417010(Path_GasCountDown* pTlv, int tlvInfo)
     if (sGasTimer_5C1BE8)
     {
         field_74_time_left = static_cast<short>((field_76_time - (sGnFrame_5C1B84 - sGasTimer_5C1BE8)) / 30);
+        if (field_74_time_left < 0)
+        {
+            field_74_time_left = 0;
+        }
+
         auto pAlarm = alive_new<Alarm>();
         if (pAlarm)
         {


### PR DESCRIPTION
Fixes this issue: https://github.com/AliveTeam/alive_reversing/issues/312

The gas timer was able to become negative after a quikload, causing the game to crash. The timer could become negative also in the original implementation, but without a crash. Adding this simple check seems to fix the problem.