### PR TITLE
A fix to the explosion knockback bug

### DIFF
--- a/Source/AliveLib/Explosion.cpp
+++ b/Source/AliveLib/Explosion.cpp
@@ -13,7 +13,7 @@
 #include "stdlib.hpp"
 #include "Slig.hpp"
 
-ALIVE_VAR(1, 0x5C1BB6, short, word_5C1BB6, 0);
+ALIVE_VAR(1, 0x5C1BB6, short, word_5C1BB6, 1);
 
 Explosion* Explosion::ctor_4A1200(FP xpos, FP ypos, FP scale, __int16 bSmall)
 {


### PR DESCRIPTION
Fixes this issue: https://github.com/AliveTeam/alive_reversing/issues/335

The stand alone version assigned `word_5C1BB6` to 0 whereas the actual value in 0x5C1BB6 is 1 (used by the hook version). This constant determines the value of `ScreenShake::field_42` which determines whether an event broadcasts of type `kEventScreenShake` is triggered which leads to the knockbacks.