### PR TITLE
Named fields, flags and functions in more classes. Matched AO's OrbWhirlWind and OrbWhirlWindParticle classes to AE counterparts.

### DIFF
--- a/Source/AliveLibAE/Abe.cpp
+++ b/Source/AliveLibAE/Abe.cpp
@@ -2069,14 +2069,7 @@ __int16 Abe::vTakeDamage_44BB50(BaseGameObject* pFrom)
 
     if (CantBeDamaged_44BAB0())
     {
-        // Fixes a bug where Abe can trigger a bomb in front of an open door and enter the door at the same time, preventing him from being killed by the bomb.
-        if (((pFrom->field_4_typeId != Types::eBaseBomb_46 || pFrom->field_4_typeId != Types::eExplosion_109) && field_106_current_motion != eAbeStates::State_114_DoorEnter_459470) ||
-            (pFrom->field_4_typeId == Types::eBullet_15 && field_106_current_motion == eAbeStates::State_114_DoorEnter_459470))
-        {
-            return 0;
-        }
-
-        LOG_INFO("Trying to enter a door while hitting a bomb or explosion.");
+        return 0;
     }
 
     if (gAbeBulletProof_5C1BDA)

--- a/Source/AliveLibAE/Abe.cpp
+++ b/Source/AliveLibAE/Abe.cpp
@@ -2069,7 +2069,14 @@ __int16 Abe::vTakeDamage_44BB50(BaseGameObject* pFrom)
 
     if (CantBeDamaged_44BAB0())
     {
-        return 0;
+        // Fixes a bug where Abe can trigger a bomb in front of an open door and enter the door at the same time, preventing him from being killed by the bomb.
+        if (((pFrom->field_4_typeId != Types::eBaseBomb_46 || pFrom->field_4_typeId != Types::eExplosion_109) && field_106_current_motion != eAbeStates::State_114_DoorEnter_459470) ||
+            (pFrom->field_4_typeId == Types::eBullet_15 && field_106_current_motion == eAbeStates::State_114_DoorEnter_459470))
+        {
+            return 0;
+        }
+
+        LOG_INFO("Trying to enter a door while hitting a bomb or explosion.");
     }
 
     if (gAbeBulletProof_5C1BDA)
@@ -3930,7 +3937,7 @@ void Abe::State_14_HoistIdle_452440()
             {
                 if (gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapTop_2, this, -1))
                 {
-                    sub_4945B0();
+                    PSX_Prevent_Rendering_4945B0();
                     field_106_current_motion = eAbeStates::State_68_ToOffScreenHoist_454B80;
                     return;
                 }
@@ -6190,11 +6197,11 @@ void Abe::State_70_RingRopePullHang_455AF0()
     PullRingRope* pPullRing = static_cast<PullRingRope*>(sObjectIds_5C1B70.Find_449CF0(field_15C_pull_rope_id));
     if (pPullRing)
     {
-        if (!pPullRing->Vsub_49BC90())
+        if (!pPullRing->VIsNotBeingPulled_49BC90())
         {
             return;
         }
-        pPullRing->Vsub_49B610();
+        pPullRing->VMarkAsPulled_49B610();
     }
 
     field_15C_pull_rope_id = -1;

--- a/Source/AliveLibAE/Game.cpp
+++ b/Source/AliveLibAE/Game.cpp
@@ -227,7 +227,7 @@ EXPORT int CC Game_End_Frame_4950F0(DWORD flags)
 {
     if (flags & 1)
     {
-        byte_BD0F20 = 0;
+        turn_off_rendering_BD0F20 = 0;
         return 0;
     }
 

--- a/Source/AliveLibAE/LiftPoint.cpp
+++ b/Source/AliveLibAE/LiftPoint.cpp
@@ -119,8 +119,8 @@ LiftPoint* LiftPoint::ctor_461030(Path_LiftPoint* pTlv, int tlvInfo)
     const FP oldX = field_B8_xpos;
     MapFollowMe_408D10(TRUE);
     const short xSnapDelta = FP_GetExponent(field_B8_xpos - oldX);
-    field_11C -= xSnapDelta;
-    field_11E -= xSnapDelta;
+    field_11C_x_offset -= xSnapDelta;
+    field_11E_width_offset -= xSnapDelta;
 
     field_20_animation.field_4_flags.Set(AnimFlags::eBit15_bSemiTrans);
 
@@ -656,7 +656,7 @@ void LiftPoint::vUpdate_461AE0()
             if (pLiftTlv)
             {
                 sub_461000(pLiftTlv);
-                field_270_floorYLevel = FP_FromInteger(pLiftTlv->field_8_top_left.field_2_y + -field_120);
+                field_270_floorYLevel = FP_FromInteger(pLiftTlv->field_8_top_left.field_2_y + -field_120_y_offset);
             }
             else
             {
@@ -896,7 +896,7 @@ void LiftPoint::vStayOnFloor_461A00(__int16 floor, Path_LiftPoint* pTlv)
 {
     if (!floor)
     {
-        field_BC_ypos = FP_FromInteger(pTlv->field_8_top_left.field_2_y + -field_120);
+        field_BC_ypos = FP_FromInteger(pTlv->field_8_top_left.field_2_y + -field_120_y_offset);
         SFX_Play_46FA90(SoundEffect::LiftStop_30, 0);
         SFX_Play_46FBA0(SoundEffect::LiftStop_30, 80, -2000);
     }

--- a/Source/AliveLibAE/Paramite.cpp
+++ b/Source/AliveLibAE/Paramite.cpp
@@ -4036,12 +4036,12 @@ void Paramite::M_RopePull_15_48D930()
 {
     auto pPullRingRope = static_cast<PullRingRope*>(sObjectIds_5C1B70.Find_449CF0(field_124_pull_ring_rope_id));
     if (!pPullRingRope || 
-        ((pPullRingRope && pPullRingRope->Vsub_49BC90()) && 
+        ((pPullRingRope && pPullRingRope->VIsNotBeingPulled_49BC90()) && 
         (sControlledCharacter_5C1B8C == this || field_108_next_motion == eParamiteMotions::M_Falling_11_48B200)))
     {
         if (pPullRingRope)
         {
-            pPullRingRope->Vsub_49B610();
+            pPullRingRope->VMarkAsPulled_49B610();
         }
         field_124_pull_ring_rope_id = -1;
         field_C8_vely = FP_FromInteger(0);

--- a/Source/AliveLibAE/PauseMenu.cpp
+++ b/Source/AliveLibAE/PauseMenu.cpp
@@ -387,7 +387,7 @@ void DumpMenus()
         menuAddr << std::hex << a.address;
         
         int count = 0;
-        PauseMenuPageEntry * c = reinterpret_cast<PauseMenuPageEntry *>(a.address);
+        PauseMenuPageEntry* c = reinterpret_cast<PauseMenuPageEntry*>(a.address);
 
         while (c->field_8_text)
         {
@@ -397,7 +397,7 @@ void DumpMenus()
         
         output << "PauseMenuPageEntry PauseMenu__PageEntryList_" + a.name + "_" + menuAddr.str() + "[" + std::to_string(count + 1) + "] =\n{\n";
         
-        PauseMenuPageEntry * e = reinterpret_cast<PauseMenuPageEntry *>(a.address);
+        PauseMenuPageEntry* e = reinterpret_cast<PauseMenuPageEntry*>(a.address);
 
         while (e->field_8_text)
         {
@@ -463,7 +463,7 @@ void PauseMenu::VRender(int** pOrderingTable)
 
 void PauseMenu::VScreenChanged()
 {
-    vsub_490D30();
+    Remove_At_Credits_Screen_490D30();
 }
 
 PauseMenu::PauseMenu()
@@ -491,12 +491,12 @@ PauseMenu * PauseMenu::ctor_48FB80()
 
     gObjList_drawables_5C1124->Push_Back(this);
 
-    field_136 = 0;
-    field_138 = 0;
-    field_13A = 0;
+    field_136_unused = 0;
+    field_138_control_action_page_index = 0;
+    field_13A_unused = 0;
     field_13C_save_state = SaveState::ReadingInput_0;
-    field_13E = 0;
-    field_140 = 0;
+    field_13E_unused = 0;
+    field_140_unused = 0;
 
     field_F4_font.ctor_433590(256, pal_554474, &sFont1Context_5BC5C8);
     
@@ -537,9 +537,9 @@ void PauseMenu::Init_491760()
     ResourceManager::LoadResourceFile_49C170("EMOANGRY.BAN", 0);
     Add_Resource_4DC130(ResourceManager::Resource_Animation, ResourceID::kAngryiconResID);
     ResourceManager::LoadResourceFile_49C170("EMONORM.BAN", 0);
-    BYTE **v2 = Add_Resource_4DC130(ResourceManager::Resource_Animation, ResourceID::kNormaliconResID);
+    BYTE **ppAnimData = Add_Resource_4DC130(ResourceManager::Resource_Animation, ResourceID::kNormaliconResID);
 
-    if (field_158_animation.Init_40A030(1248, gObjList_animations_5C1A24, this, 54, 47, v2, 1, 0, 0))
+    if (field_158_animation.Init_40A030(1248, gObjList_animations_5C1A24, this, 54, 47, ppAnimData, 1, 0, 0))
     {
         this->field_158_animation.field_C_render_layer = field_20_animation.field_C_render_layer;
         this->field_158_animation.field_14_scale = field_CC_sprite_scale;
@@ -553,16 +553,16 @@ void PauseMenu::Init_491760()
     }
 }
 
-void PauseMenu::Render_490BD0(int ** ot)
+void PauseMenu::Render_490BD0(int** ot)
 {
-    field_142 = 0;
+    field_142_poly_offset = 0;
 
     // Render the page
     (this->*field_144_active_menu.field_4_fn_render)(ot, &field_144_active_menu);
     
     // Draw a full screen polygon that "dims" out the screen while paused
-    Prim_SetTPage* pTPage = &field_1F0[gPsxDisplay_5C1130.field_C_buffer_index];
-    Poly_F4* pPolys = &field_210[gPsxDisplay_5C1130.field_C_buffer_index];
+    Prim_SetTPage* pTPage = &field_1F0_primitives[gPsxDisplay_5C1130.field_C_buffer_index];
+    Poly_F4* pPolys = &field_210_polygons[gPsxDisplay_5C1130.field_C_buffer_index];
     PolyF4_Init_4F8830(pPolys);
     Poly_Set_SemiTrans_4F8A60(&pPolys->mBase.header, TRUE);
     Poly_Set_Blending_4F8A20(&pPolys->mBase.header, FALSE);
@@ -580,7 +580,7 @@ void PauseMenu::Render_490BD0(int ** ot)
     pScreenManager_5BB5F4->InvalidateRect_40EC90(0, 0, 640, 240, pScreenManager_5BB5F4->field_3A_idx);
 }
 
-EXPORT void PauseMenu::vsub_490D30()
+EXPORT void PauseMenu::Remove_At_Credits_Screen_490D30()
 {
     if (gMap_5C3030.field_A_level == LevelIds::eCredits_16)
     {
@@ -594,16 +594,16 @@ EXPORT void PauseMenu::vsub_490D30()
 class CustomPauseMenu;
 struct CustomPauseMenuItem
 {
-    const char * text;
-    std::function<void(CustomPauseMenu *)> callback;
+    const char* text;
+    std::function<void(CustomPauseMenu*)> callback;
 };
 
-std::vector<CustomPauseMenu *> customMenuStack;
+std::vector<CustomPauseMenu*> customMenuStack;
 
 class CustomPauseMenu
 {
 public:
-    CustomPauseMenu(std::vector<CustomPauseMenuItem> * items, const char * titleStr)
+    CustomPauseMenu(std::vector<CustomPauseMenuItem>* items, const char* titleStr)
     {
         entries = items;
         title = std::string(titleStr);
@@ -654,7 +654,7 @@ public:
         mMenuPage.field_10_background_b = 127;
     }
 
-    void SetText(char * text)
+    void SetText(char* text)
     {
         (*entries)[index].text = text;
         compiledEntries[index].field_8_text = text;
@@ -668,7 +668,7 @@ public:
         customMenuStack.clear();
     }
 
-    void Update(PauseMenu * pm)
+    void Update(PauseMenu* pm)
     {
         auto input = sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_C_held;
         if (input & InputCommands::eDown)
@@ -713,13 +713,13 @@ public:
         SetLastPageStack(pPauseMenu_5C9300);
     }
 
-    void GoBack(PauseMenu * pm)
+    void GoBack(PauseMenu* pm)
     {
         customMenuStack.pop_back();
         SetLastPageStack(pm);
     }
 
-    void SetLastPageStack(PauseMenu * pm)
+    void SetLastPageStack(PauseMenu* pm)
     {
         if (customMenuStack.size() > 0)
             memcpy(&pm->field_144_active_menu, &customMenuStack[customMenuStack.size() - 1]->mMenuPage, sizeof(pm->field_144_active_menu));
@@ -728,7 +728,7 @@ public:
     }
 
 public:
-    std::vector<CustomPauseMenuItem> * entries;
+    std::vector<CustomPauseMenuItem>* entries;
     int index = 0;
     int scrollDownIndex = 0;
     int maxScrollDown = 5;
@@ -818,13 +818,13 @@ void DestroyAllObjects()
 }
 
 std::vector<CustomPauseMenuItem> devCheatsMenuItems({
-    { "Destroy Alive Objs", [](CustomPauseMenu * pm) { DestroyAliveObjects(); pm->ClosePauseMenu(); DEV_CONSOLE_MESSAGE("Destroyed Alive Objects", 4); } },
-    { "Destroy All Objects", [](CustomPauseMenu * pm) { DestroyAllObjects(); pm->ClosePauseMenu(); DEV_CONSOLE_MESSAGE("Destroyed All Objects", 4); } },
-    { "Save All Mudokons", [](CustomPauseMenu *) { sRescuedMudokons_5C1BC2 = 300; sKilledMudokons_5C1BC0 = 0; DEV_CONSOLE_MESSAGE("(CHEAT) Saved all Mudokons", 4); } },
-    { "Kill All Mudokons", [](CustomPauseMenu *) { sRescuedMudokons_5C1BC2 = 0; sKilledMudokons_5C1BC0 = 300; DEV_CONSOLE_MESSAGE("(CHEAT) Killed all Mudokons", 4); }  },
-    { "Give Rocks", [](CustomPauseMenu *) { sActiveHero_5C1B68->field_1A2_throwable_count = 99; DEV_CONSOLE_MESSAGE("(CHEAT) Got Bones", 4); }  },
-    { "Open All Doors", [](CustomPauseMenu * pm) {  pm->ClosePauseMenu(); Cheat_OpenAllDoors(); } },
-    { "Invisible", [](CustomPauseMenu * pm) { DEV_CONSOLE_MESSAGE("(CHEAT) Invisibility!", 4);  pm->ClosePauseMenu(); sActiveHero_5C1B68->field_170_invisible_timer = 65535; sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit9);  sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit8_bInvisible); } },
+    { "Destroy Alive Objs", [](CustomPauseMenu* pm) { DestroyAliveObjects(); pm->ClosePauseMenu(); DEV_CONSOLE_MESSAGE("Destroyed Alive Objects", 4); } },
+    { "Destroy All Objects", [](CustomPauseMenu* pm) { DestroyAllObjects(); pm->ClosePauseMenu(); DEV_CONSOLE_MESSAGE("Destroyed All Objects", 4); } },
+    { "Save All Mudokons", [](CustomPauseMenu*) { sRescuedMudokons_5C1BC2 = 300; sKilledMudokons_5C1BC0 = 0; DEV_CONSOLE_MESSAGE("(CHEAT) Saved all Mudokons", 4); } },
+    { "Kill All Mudokons", [](CustomPauseMenu*) { sRescuedMudokons_5C1BC2 = 0; sKilledMudokons_5C1BC0 = 300; DEV_CONSOLE_MESSAGE("(CHEAT) Killed all Mudokons", 4); }  },
+    { "Give Rocks", [](CustomPauseMenu*) { sActiveHero_5C1B68->field_1A2_throwable_count = 99; DEV_CONSOLE_MESSAGE("(CHEAT) Got Bones", 4); }  },
+    { "Open All Doors", [](CustomPauseMenu* pm) {  pm->ClosePauseMenu(); Cheat_OpenAllDoors(); } },
+    { "Invisible", [](CustomPauseMenu* pm) { DEV_CONSOLE_MESSAGE("(CHEAT) Invisibility!", 4);  pm->ClosePauseMenu(); sActiveHero_5C1B68->field_170_invisible_timer = 65535; sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit9);  sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit8_bInvisible); } },
     { "Give Explosive Fart", [](CustomPauseMenu * pm) {
         DEV_CONSOLE_MESSAGE("(CHEAT) Oh man that stinks.", 4);
         pm->ClosePauseMenu();
@@ -871,15 +871,13 @@ void PauseMenu_ForceLink() {
     if (RunningAsInjectedDll())
     {
         //DumpMenus();
-
-        
     }
 
     devTeleportMenuItems.clear();
 
     for (int i = 0; i < 17; i++)
     {
-        devTeleportMenuItems.push_back({ gPerLvlData_561700[i].field_0_display_name, [](CustomPauseMenu * pm) {
+        devTeleportMenuItems.push_back({ gPerLvlData_561700[i].field_0_display_name, [](CustomPauseMenu* pm) {
             const auto levelSelectEntry = gPerLvlData_561700[pm->index];
             pm->ClosePauseMenu();
             sActiveHero_5C1B68->field_106_current_motion = eAbeStates::State_3_Fall_459B60;
@@ -911,10 +909,10 @@ void PauseMenu_ForceLink() {
 #endif
 }
 
-void PauseMenu::Page_Base_Render_490A50(int ** ot, PauseMenu::PauseMenuPage * mp)
+void PauseMenu::Page_Base_Render_490A50(int** ot, PauseMenu::PauseMenuPage* mp)
 {
     int i = 0;
-    PauseMenuPageEntry * e = &mp->field_8_menu_items[i];
+    PauseMenuPageEntry* e = &mp->field_8_menu_items[i];
 
     while (e->field_8_text)
     {
@@ -947,7 +945,7 @@ void PauseMenu::Page_Base_Render_490A50(int ** ot, PauseMenu::PauseMenuPage * mp
             }
         }
 
-        field_142 = static_cast<short>(field_F4_font.DrawString_4337D0(
+        field_142_poly_offset = static_cast<short>(field_F4_font.DrawString_4337D0(
             ot,
             textFormatted,
             x, // X
@@ -959,7 +957,7 @@ void PauseMenu::Page_Base_Render_490A50(int ** ot, PauseMenu::PauseMenuPage * mp
             static_cast<char>(glow + e->field_C_r),
             static_cast<char>(glow + e->field_D_g),
             static_cast<char>(glow + e->field_E_b),
-            field_142,
+            field_142_poly_offset,
             FP_FromDouble(1.0),
             640,
             0));
@@ -1015,23 +1013,23 @@ void PauseMenu::Page_Main_Update_4903E0()
 {
     if (sInputObject_5BD4E0.isHeld(InputCommands::eDown))
     {
-        if (++field_134_Index_Main > MainPages::ePage_Quit_7)
+        if (++field_134_index_main > MainPages::ePage_Quit_7)
         {
-            field_134_Index_Main = MainPages::ePage_Continue_0;
+            field_134_index_main = MainPages::ePage_Continue_0;
         }
         SFX_Play_46FBA0(SoundEffect::MenuNavigation_52, 45, 400);
     }
 
     if (sInputObject_5BD4E0.isHeld(InputCommands::eUp))
     {
-        if (--field_134_Index_Main < MainPages::ePage_Continue_0)
+        if (--field_134_index_main < MainPages::ePage_Continue_0)
         {
-            field_134_Index_Main = MainPages::ePage_Quit_7;
+            field_134_index_main = MainPages::ePage_Quit_7;
         }
         SFX_Play_46FBA0(SoundEffect::MenuNavigation_52, 45, 400);
     }
 
-    field_144_active_menu.field_C_selected_index = field_134_Index_Main;
+    field_144_active_menu.field_C_selected_index = field_134_index_main;
 
     if (sInputObject_5BD4E0.isHeld(InputCommands::eBack))
     {
@@ -1041,7 +1039,7 @@ void PauseMenu::Page_Main_Update_4903E0()
     }
     else if (sInputObject_5BD4E0.isHeld(InputCommands::eUnPause_OrConfirm))
     {
-        switch (field_134_Index_Main)
+        switch (field_134_index_main)
         {
         case MainPages::ePage_Continue_0:
             word12C_flags &= ~1u;
@@ -1056,30 +1054,30 @@ void PauseMenu::Page_Main_Update_4903E0()
             Quicksave_4C90D0();
             return;
 
-        case MainPages::ePage_2:
+        case MainPages::ePage_Controls_2:
 #if DEVELOPER_MODE
             devMenu.Activate();
 #else
-            field_136 = 1;
+            field_136_unused = 1;
             field_144_active_menu = sPM_Page_Controls_Actions_546610;
-            field_138 = 0;
+            field_138_control_action_page_index = 0;
 #endif
             break;
 
         case MainPages::ePage_Status_3:
-            field_136 = 3;
+            field_136_unused = 3;
             field_144_active_menu = sPM_Page_Status_5465F8;
             break;
 
         case MainPages::ePage_Save_4:
-            field_136 = 5;
+            field_136_unused = 5;
             field_144_active_menu = sPM_Page_Save_5465C8;
             SFX_Play_46FA90(SoundEffect::IngameTransition_84, 90);
             field_13C_save_state = SaveState::ReadingInput_0;
             word12C_flags &= ~0xA;
-            field_13E = -1;
+            field_13E_unused = -1;
             word12C_flags |= 0x400;
-            field_13A = 0;
+            field_13A_unused = 0;
             Quicksave_4C90D0();
             // Set the default save name to be the current level/path/camera
             Path_Format_CameraName_460FB0(
@@ -1096,14 +1094,14 @@ void PauseMenu::Page_Main_Update_4903E0()
 
         case MainPages::ePage_Load_5:
             Quicksave_FindSaves_4D4150();
-            field_136 = 4;
+            field_136_unused = 4;
             field_144_active_menu = sPM_Page_Load_546628;
             SFX_Play_46FA90(SoundEffect::IngameTransition_84, 90);
             word12C_flags &= ~0xA;
             field_13C_save_state = SaveState::ReadingInput_0;
             word12C_flags |= 0x400;
-            field_13E = -1;
-            field_13A = 0;
+            field_13E_unused = -1;
+            field_13A_unused = 0;
             return;
 
         case MainPages::ePage_RestartPath_6:
@@ -1111,9 +1109,9 @@ void PauseMenu::Page_Main_Update_4903E0()
             return;
 
         case MainPages::ePage_Quit_7:
-            field_136 = 2;
+            field_136_unused = 2;
             field_144_active_menu = sPM_Page_ReallyQuit_5465E0;
-            field_134_Index_Main = MainPages::ePage_Continue_0;
+            field_134_index_main = MainPages::ePage_Continue_0;
             break;
 
         default:
@@ -1128,14 +1126,14 @@ void PauseMenu::Page_ControlsActions_Update_48FA60()
 {
     if (sInputObject_5BD4E0.isHeld(InputCommands::eBack))
     {
-        field_136 = 0;
+        field_136_unused = 0;
         field_144_active_menu = sPM_Page_Main_5465B0;
         SFX_Play_46FBA0(SoundEffect::PossessEffect_17, 40, 2400);
     }
 
     if (sInputObject_5BD4E0.isHeld(0x100000))
     {
-        const int prev = ++field_138;
+        const int prev = ++field_138_control_action_page_index;
         if (prev < 6)
         {
             field_144_active_menu.field_8_menu_items = sControlActionsPages_55DE40[prev];
@@ -1143,8 +1141,8 @@ void PauseMenu::Page_ControlsActions_Update_48FA60()
         }
         else
         {
-            field_138 = 0;
-            field_136 = 0;
+            field_138_control_action_page_index = 0;
+            field_136_unused = 0;
             field_144_active_menu = sPM_Page_Main_5465B0;
             SFX_Play_46FBA0(SoundEffect::PossessEffect_17, 40, 2400);
         }
@@ -1155,7 +1153,7 @@ void PauseMenu::Page_ReallyQuit_Update_490930()
 {
     if (sInputObject_5BD4E0.isHeld(InputCommands::eBack))
     {
-        field_136 = 0;
+        field_136_unused = 0;
         field_144_active_menu = sPM_Page_Main_5465B0;
         SFX_Play_46FBA0(SoundEffect::PossessEffect_17, 40, 2400);
     }
@@ -1249,7 +1247,7 @@ void PauseMenu::Page_Save_Update_491210()
         // Escape - cancel
         case VK_ESCAPE:
             SFX_Play_46FBA0(SoundEffect::PossessEffect_17, 40, 2400);
-            field_136 = 0;
+            field_136_unused = 0;
             field_144_active_menu = sPM_Page_Main_5465B0;
             Input_Reset_492660();
             return;
@@ -1342,7 +1340,7 @@ void PauseMenu::Page_Status_Update_4916A0()
     if (sInputObject_5BD4E0.isHeld(0x300000))
     {
         // Go back to the main page
-        field_136 = 0;
+        field_136_unused = 0;
         field_144_active_menu = sPM_Page_Main_5465B0;
         SFX_Play_46FBA0(SoundEffect::PossessEffect_17, 40, 2400);
     }
@@ -1427,7 +1425,7 @@ void PauseMenu::Page_Load_Update_490D50()
     // Load save (enter)
     if (inputHeld & InputCommands::eUnPause_OrConfirm)
     {
-        field_136 = 0;
+        field_136_unused = 0;
         memcpy(&field_144_active_menu, &sPM_Page_Main_5465B0, sizeof(field_144_active_menu));
         if (sTotalSaveFilesCount_BB43E0)
         {
@@ -1450,7 +1448,7 @@ void PauseMenu::Page_Load_Update_490D50()
     // Go back (esc)
     else if (inputHeld & InputCommands::eBack)
     {
-        field_136 = 0;
+        field_136_unused = 0;
         memcpy(&field_144_active_menu, &sPM_Page_Main_5465B0, sizeof(field_144_active_menu));
         SFX_Play_46FBA0(SoundEffect::PossessEffect_17, 40, 2400);
     }
@@ -1467,7 +1465,7 @@ void PauseMenu::Page_Load_Update_490D50()
     }
 }
 
-void PauseMenu::Page_Load_Render_4910A0(int ** ot, PauseMenuPage * mp)
+void PauseMenu::Page_Load_Render_4910A0(int** ot, PauseMenuPage* mp)
 {
     int saveIdx = sSavedGameToLoadIdx_BB43FC - 2;
     for (int i = 0; i < 6; i++)
@@ -1590,11 +1588,11 @@ void PauseMenu::Update_48FD80()
                 SFX_Play_46FBA0(SoundEffect::PossessEffect_17, 40, 2400);
                 sub_4A2B70();
                 field_6_flags.Set(BaseGameObject::eDrawable_Bit4);
-                field_134_Index_Main = MainPages::ePage_Continue_0;
-                field_136 = 0;
+                field_134_index_main = MainPages::ePage_Continue_0;
+                field_136_unused = 0;
                 word12C_flags = (word12C_flags & ~8) | 1;
                 field_12E_selected_glow = 40;
-                field_130 = 8;
+                field_130_selected_glow_counter = 8;
                 Path_Format_CameraName_460FB0(
                     sScreenStringBuffer_5C92F0,
                     gMap_5C3030.field_0_current_level,
@@ -1683,27 +1681,27 @@ void PauseMenu::Update_48FD80()
                         gPsxDisplay_5C1130.PSX_Display_Render_OT_41DDF0();
                         sInputObject_5BD4E0.Update_45F040();
 
-                        if (field_130 > 0)
+                        if (field_130_selected_glow_counter > 0)
                         {
                             field_12E_selected_glow += 8;
                         }
 
-                        if (field_12E_selected_glow <= 120 || field_130 <= 0)
+                        if (field_12E_selected_glow <= 120 || field_130_selected_glow_counter <= 0)
                         {
-                            if (field_130 <= 0)
+                            if (field_130_selected_glow_counter <= 0)
                             {
                                 field_12E_selected_glow -= 8;
                                 if (field_12E_selected_glow < 40)
                                 {
-                                    field_130 = -field_130;
-                                    field_12E_selected_glow += field_130;
+                                    field_130_selected_glow_counter = -field_130_selected_glow_counter;
+                                    field_12E_selected_glow += field_130_selected_glow_counter;
                                 }
                             }
                         }
                         else
                         {
-                            field_130 = -field_130;
-                            field_12E_selected_glow += field_130;
+                            field_130_selected_glow_counter = -field_130_selected_glow_counter;
+                            field_12E_selected_glow += field_130_selected_glow_counter;
                         }
 
                         (this->*field_144_active_menu.field_0_fn_update)();

--- a/Source/AliveLibAE/PauseMenu.hpp
+++ b/Source/AliveLibAE/PauseMenu.hpp
@@ -38,7 +38,7 @@ struct PauseMenuPageEntry
     __int16 field_2_x;
     __int16 field_4_y;
     __int16 field_6_unknown;
-    const char *field_8_text;
+    const char* field_8_text;
     unsigned char field_C_r;
     unsigned char field_D_g;
     unsigned char field_E_b;
@@ -67,7 +67,7 @@ public:
     EXPORT void Update_48FD80();
     EXPORT void Render_490BD0(int** ot);
 
-    EXPORT void vsub_490D30();
+    EXPORT void Remove_At_Credits_Screen_490D30();
 
     EXPORT void Page_Main_Update_4903E0();
     EXPORT void Page_Base_Render_490A50(int** ot, PauseMenuPage* mp);
@@ -100,9 +100,9 @@ public:
         char field_E_background_r;
         char field_F_background_g;
         char field_10_background_b;
-        char field_11;
-        char field_12;
-        char field_13;
+        char field_11_padding;
+        char field_12_padding;
+        char field_13_padding;
     };
     ALIVE_ASSERT_SIZEOF(PauseMenu::PauseMenuPage, 0x14);
 
@@ -113,14 +113,14 @@ public:
     Alive::Font field_F4_font;
     __int16 word12C_flags;
     __int16 field_12E_selected_glow;
-    __int16 field_130;
-    __int16 field_132;
+    __int16 field_130_selected_glow_counter;
+    __int16 field_132_padding;
 
     enum MainPages : __int16
     {
         ePage_Continue_0 = 0,
         ePage_QuickSave_1 = 1,
-        ePage_2 = 2,
+        ePage_Controls_2 = 2,
         ePage_Status_3 = 3,
         ePage_Save_4 = 4,
         ePage_Load_5 = 5,
@@ -128,10 +128,10 @@ public:
         ePage_Quit_7 = 7,
     };
 
-    /*MainPages*/ __int16 field_134_Index_Main;
-    __int16 field_136;
-    __int16 field_138;
-    __int16 field_13A;
+    /*MainPages*/ __int16 field_134_index_main;
+    __int16 field_136_unused;
+    __int16 field_138_control_action_page_index;
+    __int16 field_13A_unused;
 
     enum class SaveState : __int16
     {
@@ -141,14 +141,14 @@ public:
     };
     SaveState field_13C_save_state;
 
-    __int16 field_13E;
-    __int16 field_140;
-    __int16 field_142;
+    __int16 field_13E_unused;
+    __int16 field_140_unused;
+    __int16 field_142_poly_offset;
     PauseMenu::PauseMenuPage field_144_active_menu;
     Animation field_158_animation;
-    Prim_SetTPage field_1F0[2];
-    Poly_F4 field_210[2];
-    Prim_SetTPage field_248[2]; // Not used ??
+    Prim_SetTPage field_1F0_primitives[2];
+    Poly_F4 field_210_polygons[2];
+    Prim_SetTPage field_248_padding[2];
 };
 ALIVE_ASSERT_SIZEOF(PauseMenu, 0x268);
 

--- a/Source/AliveLibAE/PlatformBase.cpp
+++ b/Source/AliveLibAE/PlatformBase.cpp
@@ -62,10 +62,10 @@ void PlatformBase::AddDynamicCollision_4971C0(int maxW, int maxH, unsigned __int
         pTlv->field_8_top_left.field_2_y,
         32);
 
-    field_11C = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_0_x) - field_B8_xpos);
-    field_11E = FP_GetExponent(FP_FromInteger(pTlv->field_C_bottom_right.field_0_x) - field_B8_xpos);
-    field_120 = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_2_y) - field_BC_ypos);
-    field_122 = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_2_y) - field_BC_ypos);
+    field_11C_x_offset = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_0_x) - field_B8_xpos);
+    field_11E_width_offset = FP_GetExponent(FP_FromInteger(pTlv->field_C_bottom_right.field_0_x) - field_B8_xpos);
+    field_120_y_offset = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_2_y) - field_BC_ypos);
+    field_122_height_offset = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_2_y) - field_BC_ypos);
 
     if (!ObjList_5C1B78->Push_Back(this))
     {
@@ -91,10 +91,10 @@ void PlatformBase::dtor_4973E0()
 
 void PlatformBase::SyncCollisionLinePosition_4974E0()
 {
-    field_124_pCollisionLine->field_0_rect.x = FP_GetExponent(FP_FromInteger(field_11C) + field_B8_xpos);
-    field_124_pCollisionLine->field_0_rect.w = FP_GetExponent(FP_FromInteger(field_11E) + field_B8_xpos);
-    field_124_pCollisionLine->field_0_rect.y = FP_GetExponent(field_BC_ypos + FP_FromInteger(field_120));
-    field_124_pCollisionLine->field_0_rect.h = FP_GetExponent(field_BC_ypos + FP_FromInteger(field_122));
+    field_124_pCollisionLine->field_0_rect.x = FP_GetExponent(FP_FromInteger(field_11C_x_offset) + field_B8_xpos);
+    field_124_pCollisionLine->field_0_rect.w = FP_GetExponent(FP_FromInteger(field_11E_width_offset) + field_B8_xpos);
+    field_124_pCollisionLine->field_0_rect.y = FP_GetExponent(field_BC_ypos + FP_FromInteger(field_120_y_offset));
+    field_124_pCollisionLine->field_0_rect.h = FP_GetExponent(field_BC_ypos + FP_FromInteger(field_122_height_offset));
 }
 
 void PlatformBase::vRemoveCount_4975E0(BaseAliveGameObject* /*pObj*/)

--- a/Source/AliveLibAE/PlatformBase.hpp
+++ b/Source/AliveLibAE/PlatformBase.hpp
@@ -27,10 +27,10 @@ private:
 
 protected:
     int field_118_count;
-    __int16 field_11C;
-    __int16 field_11E;
-    __int16 field_120;
-    __int16 field_122;
+    __int16 field_11C_x_offset;
+    __int16 field_11E_width_offset;
+    __int16 field_120_y_offset;
+    __int16 field_122_height_offset;
     PathLine* field_124_pCollisionLine;
     int field_128_tlvInfo;
 };

--- a/Source/AliveLibAE/Psx.cpp
+++ b/Source/AliveLibAE/Psx.cpp
@@ -34,11 +34,11 @@ ALIVE_VAR(1, 0xBDCD54, BYTE*, sPsx_drawenv_buffer_BDCD54, nullptr);
 ALIVE_VAR(1, 0xBD1465, BYTE, sPsxEMU_show_vram_BD1465, 0);
 
 ALIVE_VAR(1, 0xC1D160, Bitmap, sPsxVram_C1D160, {});
-ALIVE_VAR(1, 0xC1D1A0, Bitmap, stru_C1D1A0, {}); // Note: never used?
+ALIVE_VAR(1, 0xC1D1A0, Bitmap, sBitmap_C1D1A0, {}); // Note: never used?
 
 ALIVE_VAR(1, 0xC2D060, PSX_DISPENV, sLastDispEnv_C2D060, {});
 ALIVE_VAR(1, 0xBD146D, BYTE, sScreenMode_BD146D, 0);
-ALIVE_VAR(1, 0xBD0F20, BYTE, byte_BD0F20, 0);
+ALIVE_VAR(1, 0xBD0F20, BYTE, turn_off_rendering_BD0F20, 0);
 ALIVE_VAR(1, 0x578324, BYTE, byte_578324, 1);
 
 
@@ -217,7 +217,7 @@ ALIVE_VAR(1, 0xC2D038, Bitmap*, spBitmap_C2D038, nullptr);
 EXPORT void CC PSX_EMU_Init_4F9CD0(bool bShowVRam)
 {
     memset(&sPsxVram_C1D160, 0, sizeof(sPsxVram_C1D160));
-    memset(&stru_C1D1A0, 0, sizeof(stru_C1D1A0));
+    memset(&sBitmap_C1D1A0, 0, sizeof(sBitmap_C1D1A0));
 
     sPsxEmu_EndFrameFnPtr_C1D17C = nullptr;
     sPsxEmu_put_disp_env_callback_C1D184 = nullptr;
@@ -435,7 +435,7 @@ EXPORT void CC PSX_EMU_VideoDeAlloc_4FA010()
         Bmp_Free_4F1950(&sPsxVram_C1D160);
         if (bDontUseXYOffsetInRender_BD1464)
         {
-            Bmp_Free_4F1950(&stru_C1D1A0);
+            Bmp_Free_4F1950(&sBitmap_C1D1A0);
             bDontUseXYOffsetInRender_BD1464 = 0;
         }
         sbBitmapsAllocated_BD145C = false;
@@ -458,7 +458,7 @@ EXPORT void CC PSX_PutDispEnv_Impl_4F5640(const PSX_DISPENV* pDispEnv, char a2)
         BMP_unlock_4F2100(&sPsxVram_C1D160);
     }
 
-    if (!byte_BD0F20 && byte_578324)
+    if (!turn_off_rendering_BD0F20 && byte_578324)
     {
         if (sPsxEMU_show_vram_BD1465)
         {
@@ -479,7 +479,7 @@ EXPORT void CC PSX_PutDispEnv_Impl_4F5640(const PSX_DISPENV* pDispEnv, char a2)
             rect.left = 0;
             rect.right = sLastDispEnv_C2D060.disp.w;
             rect.bottom = sLastDispEnv_C2D060.disp.h;
-            pBmp = &stru_C1D1A0;
+            pBmp = &sBitmap_C1D1A0;
         }
         else
         {
@@ -840,9 +840,9 @@ EXPORT void CC PSX_DispEnv_Set_4ED960(int mode)
     sDispEnv_mode_BBB9C4 = mode;
 }
 
-EXPORT void CC sub_4945B0()
+EXPORT void CC PSX_Prevent_Rendering_4945B0()
 {
-    byte_BD0F20 = 1;
+    turn_off_rendering_BD0F20 = 1;
 }
 
 // If mode is 1, game doesn't frame cap at all. If it is greater than 1, then it caps to (60 / mode) fps.

--- a/Source/AliveLibAE/Psx.hpp
+++ b/Source/AliveLibAE/Psx.hpp
@@ -53,7 +53,7 @@ EXPORT void CC PSX_SetDrawEnv_Impl_4FE420(int x, int y, int w, int h, int unknow
 EXPORT void CC PSX_CD_Normalize_FileName_4FAD90(char* pNormalized, const char* pFileName);
 EXPORT int CC PSX_CD_OpenFile_4FAE80(const char* pFileName, int bTryAllPaths);
 
-EXPORT void CC sub_4945B0();
+EXPORT void CC PSX_Prevent_Rendering_4945B0();
 
 
 EXPORT CdlLOC* CC PSX_Pos_To_CdLoc_4FADD0(int pos, CdlLOC* pLoc);
@@ -63,14 +63,14 @@ EXPORT int CC PSX_CD_File_Read_4FB210(int numSectors, void* pBuffer);
 EXPORT int CC PSX_CD_FileIOWait_4FB260(int bASync);
 
 ALIVE_VAR_EXTERN(Bitmap, sPsxVram_C1D160);
-ALIVE_VAR_EXTERN(BYTE, byte_BD0F20);
+ALIVE_VAR_EXTERN(BYTE, turn_off_rendering_BD0F20);
 ALIVE_VAR_EXTERN(PSX_DRAWENV, sPSX_EMU_DrawEnvState_C3D080);
 ALIVE_VAR_EXTERN(BYTE, sPsxEMU_show_vram_BD1465);
 ALIVE_VAR_EXTERN(Bitmap*, spBitmap_C2D038);
 
 ALIVE_VAR_EXTERN(TPsxEmuCallBack, sPsxEmu_EndFrameFnPtr_C1D17C);
 ALIVE_VAR_EXTERN(BYTE, bDontUseXYOffsetInRender_BD1464);
-ALIVE_VAR_EXTERN(Bitmap, stru_C1D1A0);
+ALIVE_VAR_EXTERN(Bitmap, sBitmap_C1D1A0);
 ALIVE_VAR_EXTERN(int, sVGA_DisplayType_BD1468);
 
 ALIVE_ARY_EXTERN(char, 128, sCdEmu_Path1_C14620);

--- a/Source/AliveLibAE/PsxDisplay.cpp
+++ b/Source/AliveLibAE/PsxDisplay.cpp
@@ -77,7 +77,7 @@ ALIVE_ARY(1, 0xC27640, DebugTexts, 4, sTexts_C27640, {});
 
 EXPORT void CC DebugFont_Reset_4F8B40()
 {
-    memset(sTexts_C27640, 0, sizeof(DebugTexts)*4); // 8240u
+    memset(sTexts_C27640, 0, sizeof(DebugTexts) * 4); // 8240u
     sFntCount_BD0F28 = 0;
 }
 
@@ -162,7 +162,7 @@ EXPORT void CC DebugFont_Flush_4DD050()
 
 namespace Test
 {
-    static void Test_sub_4F8AB0()
+    static void Test_DebugFont_4F8AB0()
     {
         DebugFont_Reset_4F8B40();
 
@@ -187,7 +187,7 @@ namespace Test
 
     void PsxDisplayTests()
     {
-        Test_sub_4F8AB0();
+        Test_DebugFont_4F8AB0();
     }
 }
 
@@ -221,7 +221,7 @@ void PsxDisplay::ctor_41DC30()
     PSX_SetVideoMode_4FA8F0();
     field_0_width = 640;
     field_2_height = 240;
-    field_4 = 0;
+    field_4_unused = 0;
     field_6_bpp = 16;
     field_8_max_buffers = 1;
     field_A_buffer_size = 43;
@@ -296,7 +296,7 @@ void PsxDisplay::PSX_Display_Render_OT_41DDF0()
             else
             {
                 pScreenManager_5BB5F4->sub_40EE10();
-                byte_BD0F20 = 1;
+                turn_off_rendering_BD0F20 = 1;
             }
             PSX_VSync_4F6170(2);
         }

--- a/Source/AliveLibAE/PsxDisplay.hpp
+++ b/Source/AliveLibAE/PsxDisplay.hpp
@@ -38,12 +38,12 @@ class PsxDisplay
 public:
     __int16 field_0_width;
     __int16 field_2_height;
-    __int16 field_4;
+    __int16 field_4_unused;
     __int16 field_6_bpp;
     __int16 field_8_max_buffers;
     unsigned __int16 field_A_buffer_size;
     unsigned __int16 field_C_buffer_index;
-    __int16 field_E;
+    __int16 field_E_padding;
     PSX_Display_Buffer field_10_drawEnv[2];
 
     EXPORT void ctor_41DC30();

--- a/Source/AliveLibAE/PsxRender.cpp
+++ b/Source/AliveLibAE/PsxRender.cpp
@@ -26,7 +26,7 @@ ALIVE_VAR(1, 0x578318, short, sActiveTPage_578318, -1);
 ALIVE_VAR(1, 0xbd0f0c, DWORD, sTexture_page_x_BD0F0C, 0);
 ALIVE_VAR(1, 0xbd0f10, DWORD, sTexture_page_y_BD0F10, 0);
 ALIVE_VAR(1, 0xbd0f14, DWORD, sTexture_mode_BD0F14, 0);
-ALIVE_VAR(1, 0x57831c, DWORD, dword_57831C, 10);
+ALIVE_VAR(1, 0x57831c, DWORD, tpage_width_57831C, 10);
 ALIVE_VAR(1, 0xBD0F18, DWORD, sTexture_page_abr_BD0F18, 0);
 ALIVE_VAR(1, 0xbd0f1c, WORD *, sTPage_src_ptr_BD0F1C, nullptr);
 
@@ -3379,7 +3379,7 @@ EXPORT void CC PSX_DrawOTag_4F6540(int** pOT)
 {
     if (!sPsxEmu_EndFrameFnPtr_C1D17C || !sPsxEmu_EndFrameFnPtr_C1D17C(0))
     {
-        if (byte_BD0F20 || !BMP_Lock_4F1FF0(&sPsxVram_C1D160))
+        if (turn_off_rendering_BD0F20 || !BMP_Lock_4F1FF0(&sPsxVram_C1D160))
         {
             if (sPsxEmu_EndFrameFnPtr_C1D17C)
             {
@@ -3393,7 +3393,7 @@ EXPORT void CC PSX_DrawOTag_4F6540(int** pOT)
 
         if (bDontUseXYOffsetInRender_BD1464)
         {
-            if (!BMP_Lock_4F1FF0(&stru_C1D1A0))
+            if (!BMP_Lock_4F1FF0(&sBitmap_C1D1A0))
             {
                 BMP_unlock_4F2100(&sPsxVram_C1D160);
                 if (sPsxEmu_EndFrameFnPtr_C1D17C)
@@ -3402,7 +3402,7 @@ EXPORT void CC PSX_DrawOTag_4F6540(int** pOT)
                 }
                 return;
             }
-            spBitmap_C2D038 = &stru_C1D1A0;
+            spBitmap_C2D038 = &sBitmap_C1D1A0;
             drawEnv_of1 = 0;
             drawEnv_of0 = 0;
         }
@@ -3420,7 +3420,7 @@ EXPORT void CC PSX_DrawOTag_4F6540(int** pOT)
 
         if (bDontUseXYOffsetInRender_BD1464)
         {
-            BMP_unlock_4F2100(&stru_C1D1A0);
+            BMP_unlock_4F2100(&sBitmap_C1D1A0);
         }
 
         BMP_unlock_4F2100(&sPsxVram_C1D160);
@@ -3455,7 +3455,7 @@ EXPORT void CC PSX_TPage_Change_4F6430(__int16 tPage)
 
         // NOTE: Branch guarded by dword_BD2250[tPage & 31] removed as it is never written
 
-        dword_57831C = 10;
+        tpage_width_57831C = 10;
         sTPage_src_ptr_BD0F1C = reinterpret_cast<WORD*>(sPsxVram_C1D160.field_4_pLockedPixels) + (sTexture_page_x_BD0F0C + (sTexture_page_y_BD0F10 * 1024));
     }
 }
@@ -3834,11 +3834,11 @@ EXPORT void CC PSX_EMU_Render_SPRT_8bit_51F660(const PSX_RECT* pRect, int u, int
 
 EXPORT void CC PSX_EMU_Render_SPRT_16bit_51FA30(const PSX_RECT* pRect, int u, int v, unsigned __int8 r, unsigned __int8 g, unsigned __int8 b, int /*clut*/, char bSemiTrans)
 {
-    const int texture_row_width = (1 << dword_57831C) - pRect->w;
+    const int texture_row_width = (1 << tpage_width_57831C) - pRect->w;
     const unsigned int line_pitch = (unsigned int)spBitmap_C2D038->field_10_locked_pitch >> 1;
     const unsigned int pitch_remainder = line_pitch - pRect->w;
 
-    const WORD* pTexture_src = &sTPage_src_ptr_BD0F1C[u + (v << dword_57831C)];// dword_57831C = tpage width/bpp? becomes / 1024 ?
+    const WORD* pTexture_src = &sTPage_src_ptr_BD0F1C[u + (v << tpage_width_57831C)];// tpage_width_57831C = tpage width/bpp? becomes / 1024 ?
     WORD* pVram_start = reinterpret_cast<WORD*>(spBitmap_C2D038->field_4_pLockedPixels) + (pRect->x + (line_pitch * pRect->y));
     WORD* pVram_end = &pVram_start[(pRect->w - 1) + line_pitch * (pRect->h - 1)];
 
@@ -4358,7 +4358,7 @@ namespace Test
         sTexture_page_x_BD0F0C = 0;
         sTexture_page_y_BD0F10 = 0;
         sTexture_mode_BD0F14 = 0;
-        dword_57831C = 0;
+        tpage_width_57831C = 0;
 
         for (DWORD i = 0; i < 3; i++)
         {
@@ -4370,7 +4370,7 @@ namespace Test
             ASSERT_EQ(sTexture_page_y_BD0F10, (i == 0) ? 0u : 256u);
             ASSERT_EQ(sTexture_mode_BD0F14, i);
             ASSERT_EQ(sTexture_page_abr_BD0F18, 3 - i);
-            ASSERT_EQ(dword_57831C, 10u);
+            ASSERT_EQ(tpage_width_57831C, 10u);
         }
     }
 

--- a/Source/AliveLibAE/PullRingRope.cpp
+++ b/Source/AliveLibAE/PullRingRope.cpp
@@ -52,7 +52,7 @@ PullRingRope* PullRingRope::ctor_49B2D0(Path_PullRingRope* pTlv, int tlvInfo)
     field_102_id = pTlv->field_10_id;
     field_104_target_action = pTlv->field_12_target_action;
     field_110_tlvInfo = tlvInfo;
-    field_100_state = State::eState_0;
+    field_100_state = State::eIdle_0;
     field_F4_stay_in_state_ticks = 0;
 
     field_BC_ypos += FP_FromInteger(pTlv->field_14_length_of_rope);
@@ -115,14 +115,14 @@ __int16 PullRingRope::VPull_49BBD0(BaseGameObject* a2)
     return vPull_49BBD0(a2);
 }
 
-BOOL PullRingRope::Vsub_49BC90()
+BOOL PullRingRope::VIsNotBeingPulled_49BC90()
 {
-    return vsub_49BC90();
+    return vIsNotBeingPulled_49BC90();
 }
 
-void PullRingRope::Vsub_49B610()
+void PullRingRope::VMarkAsPulled_49B610()
 {
-    return vsub_49B610();
+    return vMarkAsPulled_49B610();
 }
 
 PullRingRope* PullRingRope::vdtor_49B630(signed int flags)
@@ -168,7 +168,7 @@ void PullRingRope::vUpdate_49B720()
 
     switch (field_100_state)
     {
-    case State::eState_1:
+    case State::eBeingPulled_1:
         if (field_20_animation.field_92_current_frame == 2)
         {
             SFX_Play_46FA90(SoundEffect::RingRopePull_56, 0);
@@ -181,8 +181,8 @@ void PullRingRope::vUpdate_49B720()
         if (field_F4_stay_in_state_ticks == 0)
         {
             field_C8_vely = FP_FromInteger(0);
-            field_10C &= ~1u;
-            field_100_state = State::eState_2;
+            field_10C_is_pulled &= ~1u;
+            field_100_state = State::eTriggerEvent_2;
 
             if (gMap_5C3030.field_0_current_level == LevelIds::eMines_1 ||
                 gMap_5C3030.field_0_current_level == LevelIds::eBonewerkz_8 ||
@@ -195,12 +195,12 @@ void PullRingRope::vUpdate_49B720()
         }
         break;
 
-    case State::eState_2:
-        if (field_10C & 1)
+    case State::eTriggerEvent_2:
+        if (field_10C_is_pulled & 1)
         {
             field_C8_vely = FP_FromInteger(4) * field_CC_sprite_scale;
             field_FC_ring_puller_id = -1;
-            field_100_state = State::eState_3;
+            field_100_state = State::eReturnToIdle_3;
             field_F4_stay_in_state_ticks = 3;
             field_20_animation.Set_Animation_Data_409C80(3092, 0);
 
@@ -255,13 +255,13 @@ void PullRingRope::vUpdate_49B720()
         }
         break;
 
-    case State::eState_3:
+    case State::eReturnToIdle_3:
         field_BC_ypos -= field_C8_vely;
         field_F4_stay_in_state_ticks--;
         if (field_F4_stay_in_state_ticks == 0)
         {
             field_C8_vely = FP_FromInteger(0);
-            field_100_state = State::eState_0;
+            field_100_state = State::eIdle_0;
             field_20_animation.Set_Animation_Data_409C80(3020, 0);
         }
         break;
@@ -286,13 +286,13 @@ void PullRingRope::vScreenChanged_49BCB0()
 
 __int16 PullRingRope::vPull_49BBD0(BaseGameObject* pObj)
 {
-    if (!pObj || field_100_state != State::eState_0)
+    if (!pObj || field_100_state != State::eIdle_0)
     {
         return 0;
     }
 
     field_FC_ring_puller_id = pObj->field_8_object_id;
-    field_100_state = State::eState_1;
+    field_100_state = State::eBeingPulled_1;
     field_C8_vely = FP_FromInteger(2) * field_CC_sprite_scale;
     field_F4_stay_in_state_ticks = 6;
     field_20_animation.Set_Animation_Data_409C80(3060, 0);
@@ -301,12 +301,12 @@ __int16 PullRingRope::vPull_49BBD0(BaseGameObject* pObj)
 
 }
 
-BOOL PullRingRope::vsub_49BC90()
+BOOL PullRingRope::vIsNotBeingPulled_49BC90()
 {
-    return field_100_state != State::eState_1;
+    return field_100_state != State::eBeingPulled_1;
 }
 
-void PullRingRope::vsub_49B610()
+void PullRingRope::vMarkAsPulled_49B610()
 {
-    field_10C |= 1u;
+    field_10C_is_pulled |= 1u;
 }

--- a/Source/AliveLibAE/PullRingRope.hpp
+++ b/Source/AliveLibAE/PullRingRope.hpp
@@ -28,26 +28,26 @@ public:
     virtual void VUpdate() override;
     virtual void VScreenChanged() override;
     virtual __int16 VPull_49BBD0(BaseGameObject* a2);
-    virtual BOOL Vsub_49BC90();
-    virtual void Vsub_49B610();
+    virtual BOOL VIsNotBeingPulled_49BC90();
+    virtual void VMarkAsPulled_49B610();
 private:
     EXPORT PullRingRope* vdtor_49B630(signed int flags);
     EXPORT void dtor_49B660();
     EXPORT void vUpdate_49B720();
     EXPORT void vScreenChanged_49BCB0();
     EXPORT __int16 vPull_49BBD0(BaseGameObject* a2);
-    EXPORT BOOL vsub_49BC90();
-    EXPORT void vsub_49B610();
+    EXPORT BOOL vIsNotBeingPulled_49BC90();
+    EXPORT void vMarkAsPulled_49B610();
 private:
     int field_F4_stay_in_state_ticks;
     int field_F8_rope_id;
     int field_FC_ring_puller_id;
     enum class State : __int16
     {
-        eState_0 = 0,
-        eState_1 = 1,
-        eState_2 = 2,
-        eState_3 = 3,
+        eIdle_0 = 0,
+        eBeingPulled_1 = 1,
+        eTriggerEvent_2 = 2,
+        eReturnToIdle_3 = 3,
     };
     State field_100_state;
     __int16 field_102_id;
@@ -55,7 +55,7 @@ private:
     __int16 field_106_on_sound;
     __int16 field_108_off_sound;
     __int16 field_10A_sound_direction;
-    int field_10C;
+    int field_10C_is_pulled;
     int field_110_tlvInfo;
 };
 ALIVE_ASSERT_SIZEOF(PullRingRope, 0x114);

--- a/Source/AliveLibAE/TrapDoor.cpp
+++ b/Source/AliveLibAE/TrapDoor.cpp
@@ -170,8 +170,8 @@ EXPORT TrapDoor* TrapDoor::ctor_4DD570(Path_TrapDoor* pTlv, Map* pMap, int tlvIn
         field_20_animation.field_4_flags.Set(AnimFlags::eBit5_FlipX);
     }
 
-    field_11C = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_0_x) - field_B8_xpos);
-    field_11E = FP_GetExponent(FP_FromInteger(pTlv->field_C_bottom_right.field_0_x) - field_B8_xpos);
+    field_11C_x_offset = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_0_x) - field_B8_xpos);
+    field_11E_width_offset = FP_GetExponent(FP_FromInteger(pTlv->field_C_bottom_right.field_0_x) - field_B8_xpos);
     field_13A_xOff = pTlv->field_1C_anim_offset;
 
     if (field_136_state == TrapDoorState::eState_2)

--- a/Source/AliveLibAO/OrbWhirlWind.cpp
+++ b/Source/AliveLibAO/OrbWhirlWind.cpp
@@ -53,8 +53,8 @@ void OrbWhirlWind::VUpdate_48B990()
             if (pParticle)
             {
                 pParticle->ctor_48BC10(
-                    field_58_xpos_mid,
-                    field_5C_ypos_mid,
+                    field_58_xpos,
+                    field_5C_ypos,
                     field_60_scale);
             }
             field_18_particles[field_16_particleIdx++] = pParticle;
@@ -141,8 +141,8 @@ OrbWhirlWind* OrbWhirlWind::ctor_48B870(FP xpos, FP ypos, FP scale)
 
     field_4_typeId = Types::eNone_0;
 
-    field_58_xpos_mid = xpos;
-    field_5C_ypos_mid = ypos;
+    field_58_xpos = xpos;
+    field_5C_ypos = ypos;
     field_60_scale = scale;
 
     field_14_particles_state = ParticlesState::eCreating;

--- a/Source/AliveLibAO/OrbWhirlWind.hpp
+++ b/Source/AliveLibAO/OrbWhirlWind.hpp
@@ -44,8 +44,8 @@ public:
     ParticlesState field_14_particles_state;
     __int16 field_16_particleIdx;
     OrbWhirlWindParticle* field_18_particles[16];
-    FP field_58_xpos_mid;
-    FP field_5C_ypos_mid;
+    FP field_58_xpos;
+    FP field_5C_ypos;
     FP field_60_scale;
 };
 ALIVE_ASSERT_SIZEOF(OrbWhirlWind, 0x64);

--- a/Source/AliveLibAO/OrbWhirlWindParticle.cpp
+++ b/Source/AliveLibAO/OrbWhirlWindParticle.cpp
@@ -11,24 +11,24 @@
 
 START_NS_AO
 
-void OrbWhirlWindParticle::sub_48BDC0(__int16 a2)
+void OrbWhirlWindParticle::CalculateRenderProperties_48BDC0(__int16 bStarted)
 {
     field_B8_render_angle += field_BC_counter;
 
-    if (a2 && field_BC_counter <= field_BE_max && !(gnFrameCount_507670 % 3))
+    if (bStarted && field_BC_counter <= field_BE_max && !(gnFrameCount_507670 % 3))
     {
         field_BC_counter++;
     }
-    else if (!a2 && field_BC_counter >= 1 && !(gnFrameCount_507670 % 3))
+    else if (!bStarted && field_BC_counter >= 1 && !(gnFrameCount_507670 % 3))
     {
         field_BC_counter--;
         field_D4_radiusX += FP_FromInteger(4);
     }
 
-    field_A0_xpos_render_offset = ((field_C0_scale * field_D4_radiusX) * Math_Sine_451110(static_cast<BYTE>(field_B8_render_angle))) + field_CC_xpos_mid;
-    field_A4_ypos_render_offset = ((field_C0_scale * field_D8_radiosY) * Math_Cosine_4510A0(static_cast<BYTE>(field_B8_render_angle))) + field_D0_ypos_mid;
-    field_A8_render_as_scale = (field_C0_scale * field_C4_randomized_scale);
-    if (field_C0_scale > FP_FromDouble(0.599))
+    field_A0_xpos_render_offset = ((field_C0_current_scale * field_D4_radiusX) * Math_Sine_451110(static_cast<BYTE>(field_B8_render_angle))) + field_CC_xpos_mid;
+    field_A4_ypos_render_offset = ((field_C0_current_scale * field_D8_radiosY) * Math_Cosine_4510A0(static_cast<BYTE>(field_B8_render_angle))) + field_D0_ypos_mid;
+    field_A8_render_as_scale = (field_C0_current_scale * field_C4_randomized_scale);
+    if (field_C0_current_scale > FP_FromDouble(0.599))
     {
         field_8_anim.field_C_layer = 32;
     }
@@ -95,7 +95,7 @@ void OrbWhirlWindParticle::VUpdate_48BF00()
     switch (field_B4_state)
     {
     case State::State_0_Start:
-        sub_48BDC0(1);
+        CalculateRenderProperties_48BDC0(1);
         break;
 
     case State::State_1_Spin:
@@ -107,7 +107,7 @@ void OrbWhirlWindParticle::VUpdate_48BF00()
                 field_D4_radiusX -= FP_FromInteger(2);
                 field_D8_radiosY -= FP_FromInteger(1);
             }
-            sub_48BDC0(1);
+            CalculateRenderProperties_48BDC0(1);
         }
         else
         {
@@ -121,10 +121,10 @@ void OrbWhirlWindParticle::VUpdate_48BF00()
                 field_F0_scale = field_CC_xpos_mid;
                 field_FC_xpos_offset2 = field_D0_ypos_mid;
                 field_F4_xpos_offset = field_D0_ypos_mid;
-                field_C8_scale_offset_fly_to_target = (field_E4_pObj->field_BC_sprite_scale - field_C0_scale) / FP_FromInteger(16);
+                field_C8_scale_offset_fly_to_target = (field_E4_pObj->field_BC_sprite_scale - field_C0_current_scale) / FP_FromInteger(16);
                 field_DC_position_timer = gnFrameCount_507670 + 16;
                 field_B4_state = State::State_2_FlyToTarget;
-                sub_48BDC0(1);
+                CalculateRenderProperties_48BDC0(1);
             }
         }
         break;
@@ -136,35 +136,35 @@ void OrbWhirlWindParticle::VUpdate_48BF00()
         }
         else
         {
-            PSX_RECT v44 = {};
-            field_E4_pObj->VGetBoundingRect(&v44, 1);
+            PSX_RECT bRect = {};
+            field_E4_pObj->VGetBoundingRect(&bRect, 1);
 
-            const FP v19 = FP_FromInteger((v44.x + v44.w) / 2);
-            const FP v20 = FP_FromInteger((v44.y + v44.h) / 2);
+            const FP xpos = FP_FromInteger((bRect.x + bRect.w) / 2);
+            const FP ypos = FP_FromInteger((bRect.y + bRect.h) / 2);
 
             if (static_cast<int>(gnFrameCount_507670) < field_DC_position_timer)
             {
-                field_C0_scale += field_C8_scale_offset_fly_to_target;
+                field_C0_current_scale += field_C8_scale_offset_fly_to_target;
                 const FP v25 = FP_FromInteger(16 - (field_DC_position_timer + gnFrameCount_507670)) / FP_FromInteger(16);
-                field_F8_ypos_offset = ((v19 - field_F0_scale) * v25) + field_F0_scale;
-                field_FC_xpos_offset2 = ((v20 - field_F4_xpos_offset) * v25) + field_F4_xpos_offset;
-                field_CC_xpos_mid = field_F8_ypos_offset + ((FP_FromInteger(32) * field_C0_scale) * Math_Sine_451110(FP_GetExponent(FP_FromInteger(128) * v25) & 0xFF));
-                field_D0_ypos_mid = field_FC_xpos_offset2 + ((FP_FromInteger(32) * field_C0_scale) * Math_Cosine_4510A0(FP_GetExponent(FP_FromInteger(128) * v25) & 0xFF));
+                field_F8_ypos_offset = ((xpos - field_F0_scale) * v25) + field_F0_scale;
+                field_FC_xpos_offset2 = ((ypos - field_F4_xpos_offset) * v25) + field_F4_xpos_offset;
+                field_CC_xpos_mid = field_F8_ypos_offset + ((FP_FromInteger(32) * field_C0_current_scale) * Math_Sine_451110(FP_GetExponent(FP_FromInteger(128) * v25) & 0xFF));
+                field_D0_ypos_mid = field_FC_xpos_offset2 + ((FP_FromInteger(32) * field_C0_current_scale) * Math_Cosine_4510A0(FP_GetExponent(FP_FromInteger(128) * v25) & 0xFF));
             }
             else
             {
-                field_F8_ypos_offset = v19;
-                field_FC_xpos_offset2 = v20;
-                field_CC_xpos_mid = v19;
-                field_D0_ypos_mid = v20;
+                field_F8_ypos_offset = xpos;
+                field_FC_xpos_offset2 = ypos;
+                field_CC_xpos_mid = xpos;
+                field_D0_ypos_mid = ypos;
                 field_B8_render_angle = 192;
                 field_D4_radiusX = FP_FromInteger(40);
                 field_AC_radiusX_offset = field_D4_radiusX / FP_FromInteger(32);
-                field_100 = field_C0_scale * FP_FromInteger(Math_RandomRange_450F20(-16, 16));
+                field_104_scale_offset_spin_at_target = field_C0_current_scale * FP_FromInteger(Math_RandomRange_450F20(-16, 16));
                 field_DC_position_timer = gnFrameCount_507670 + 32;
                 field_B4_state = State::State_3_SpinAtTarget;
             }
-            sub_48BDC0(1);
+            CalculateRenderProperties_48BDC0(1);
         }
         break;
 
@@ -173,12 +173,12 @@ void OrbWhirlWindParticle::VUpdate_48BF00()
         {
             SetActive(IsActive() ? 0 : 1);
         }
-        field_D0_ypos_mid = (field_100 * Math_Cosine_4510A0(
+        field_D0_ypos_mid = (field_104_scale_offset_spin_at_target * Math_Cosine_4510A0(
             FP_GetExponent(
                 FP_FromInteger(128) *
                 FP_FromInteger(32 - (field_DC_position_timer + gnFrameCount_507670)) / FP_FromInteger(32)) & 0xFF)) + field_FC_xpos_offset2;
         field_D4_radiusX -= field_AC_radiusX_offset;
-        sub_48BDC0(1);
+        CalculateRenderProperties_48BDC0(1);
         break;
 
     case State::State_4_Stop:
@@ -186,7 +186,7 @@ void OrbWhirlWindParticle::VUpdate_48BF00()
         {
             SetActive(IsActive() ? 0 : 1);
         }
-        sub_48BDC0(0);
+        CalculateRenderProperties_48BDC0(0);
         break;
 
     default:
@@ -236,9 +236,9 @@ OrbWhirlWindParticle* OrbWhirlWindParticle::ctor_48BC10(FP xpos, FP ypos, FP sca
     field_E0_yMove = ypos - FP_FromInteger(16);
     field_D4_radiusX = FP_FromInteger(Math_RandomRange_450F20(37, 43));
     field_D8_radiosY = FP_FromDouble(0.25) * field_D4_radiusX;
-    field_C0_scale = scale;
+    field_C0_current_scale = scale;
     field_C4_randomized_scale = FP_FromInteger(Math_RandomRange_450F20(7, 10)) / FP_FromInteger(10);
-    field_A8_render_as_scale = field_C0_scale * field_C4_randomized_scale;
+    field_A8_render_as_scale = field_C0_current_scale * field_C4_randomized_scale;
     return this;
 }
 
@@ -248,7 +248,7 @@ void OrbWhirlWindParticle::Spin(FP xpos, FP ypos, BaseAliveGameObject* pObj)
     field_B4_state = State::State_1_Spin;
     field_E4_pObj = pObj;
 
-    field_B0_ypos_increment = (field_C0_scale * field_E0_yMove - field_D0_ypos_mid) / FP_FromInteger(16);
+    field_B0_ypos_increment = (field_C0_current_scale * field_E0_yMove - field_D0_ypos_mid) / FP_FromInteger(16);
     field_E8_xpos = xpos;
     field_EC_ypos = ypos;
 }

--- a/Source/AliveLibAO/OrbWhirlWindParticle.hpp
+++ b/Source/AliveLibAO/OrbWhirlWindParticle.hpp
@@ -28,7 +28,7 @@ public:
     // NOTE: inlined
     void ToStop();
 
-    EXPORT void sub_48BDC0(__int16 a2);
+    EXPORT void CalculateRenderProperties_48BDC0(__int16 bStarted);
 
     void Spin(FP xpos, FP ypos, BaseAliveGameObject* pObj);
 
@@ -54,7 +54,7 @@ public:
     int field_B8_render_angle;
     __int16 field_BC_counter;
     __int16 field_BE_max;
-    FP field_C0_scale;
+    FP field_C0_current_scale;
     FP field_C4_randomized_scale;
     FP field_C8_scale_offset_fly_to_target;
     FP field_CC_xpos_mid;
@@ -70,7 +70,7 @@ public:
     FP field_F4_xpos_offset;
     FP field_F8_ypos_offset;
     FP field_FC_xpos_offset2;
-    FP field_100;
+    FP field_104_scale_offset_spin_at_target;
 };
 ALIVE_ASSERT_SIZEOF(OrbWhirlWindParticle, 0x104);
 


### PR DESCRIPTION
Named fields, flags and functions in PauseMenu, PlatformBase, Psx, PsxDisplay, (a bit of) PsxRender and PullRingRope classes. Also changed variable names in AO's OrbWhirlWind and OrbWhirlWindParticle classes to match their AE counterparts.