### PR TITLE
Fix rounding errors, improve rendering on high DPI displays

### DIFF
--- a/Source/AliveLibAE/Sys.cpp
+++ b/Source/AliveLibAE/Sys.cpp
@@ -858,7 +858,7 @@ static int CC Sys_WindowClass_Register_SDL(LPCSTR /*lpClassName*/, LPCSTR lpWind
 
     sHwnd_BBB9F4 = SDL_CreateWindow(lpWindowName, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, gScreenRect.w, gScreenRect.h, SDL_WINDOW_SHOWN | SDL_WINDOW_FULLSCREEN);
 #else
-    sHwnd_BBB9F4 = SDL_CreateWindow(lpWindowName, x, y, nWidth, nHeight, SDL_WINDOW_RESIZABLE);
+    sHwnd_BBB9F4 = SDL_CreateWindow(lpWindowName, x, y, nWidth, nHeight, SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
 #endif
 
     Input_InitKeyStateArray_4EDD60();

--- a/Source/AliveLibAE/VGA.cpp
+++ b/Source/AliveLibAE/VGA.cpp
@@ -156,20 +156,20 @@ EXPORT void CC VGA_CopyToFront_4F3730(Bitmap* pBmp, RECT* pRect, int /*screenMod
 
             int w = 0;
             int h = 0;
-            SDL_GetWindowSize(Sys_GetHWnd_4F2C70(), &w, &h);
+            SDL_GL_GetDrawableSize(Sys_GetHWnd_4F2C70(), &w, &h);
 
             int renderedWidth = w;
             int renderedHeight = h;
 
             if (s_VGA_KeepAspectRatio)
             {
-                if (w > (h * 1.333))
+                if (3 * w > 4 * h)
                 {
-                    renderedWidth = static_cast<int>(h * 1.333);
+                    renderedWidth = h * 4 / 3;
                 }
                 else
                 {
-                    renderedHeight = static_cast<int>(w * 0.75);
+                    renderedHeight = w * 3 / 4;
                 }
             }
 

--- a/Source/AliveLibAE/VGA.cpp
+++ b/Source/AliveLibAE/VGA.cpp
@@ -156,7 +156,7 @@ EXPORT void CC VGA_CopyToFront_4F3730(Bitmap* pBmp, RECT* pRect, int /*screenMod
 
             int w = 0;
             int h = 0;
-            SDL_GL_GetDrawableSize(Sys_GetHWnd_4F2C70(), &w, &h);
+            SDL_GetRendererOutputSize(gRenderer, &w, &h);
 
             int renderedWidth = w;
             int renderedHeight = h;


### PR DESCRIPTION
This commit fixes rounding error when maintaining aspect ratio, and improves rendering on Retina Macs by enabling high DPI support in SDL.