### PR TITLE
Named Variables in the Alarm, BaseAliveGameObject, GameEnderController and LaughingGas Classes

### DIFF
--- a/Source/AliveLibAE/Abe.cpp
+++ b/Source/AliveLibAE/Abe.cpp
@@ -1190,7 +1190,7 @@ signed int CC Abe::CreateFromSaveState_44D4F0(const BYTE* pData)
 
     sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit7_Electrocuted, pSaveState->bElectrocuted & 1);
     sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit8_bInvisible, pSaveState->field_42_bInvisible & 1);
-    sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit10, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_eBit13));
+    sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit10_Teleporting, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_eBit13_teleporting));
 
     sActiveHero_5C1B68->field_1AC_flags.Set(Flags_1AC::e1AC_Bit1_lift_point_dead_while_using_lift, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_Bit1_lift_point_dead_while_using_lift));
     sActiveHero_5C1B68->field_1AC_flags.Set(Flags_1AC::e1AC_Bit2_return_to_previous_motion, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_Bit2_return_to_previous_motion));
@@ -1206,7 +1206,7 @@ signed int CC Abe::CreateFromSaveState_44D4F0(const BYTE* pData)
     sActiveHero_5C1B68->field_1AC_flags.Set(Flags_1AC::e1AC_eBit13_play_ledge_grab_sounds, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_Bit10_play_ledge_grab_sounds));
     sActiveHero_5C1B68->field_1AC_flags.Set(Flags_1AC::e1AC_eBit14_unused, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_Bit11_unused));
     sActiveHero_5C1B68->field_1AC_flags.Set(Flags_1AC::e1AC_eBit15_have_healing, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_Bit12_have_healing));
-    sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit10, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_eBit13));
+    sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit10_Teleporting, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_eBit13_teleporting));
     sActiveHero_5C1B68->field_1AC_flags.Set(Flags_1AC::e1AC_eBit16_is_mudanchee_vault_ender, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_eBit14_is_mudanchee_vault_ender));
 
     sActiveHero_5C1B68->field_1AE_flags.Set(Flags_1AE::e1AE_Bit1_is_mudomo_vault_ender, pSaveState->field_D4_flags.Get(Abe_SaveState::eD4_eBit15_is_mudomo_vault_ender));
@@ -1340,9 +1340,9 @@ void Abe::Update_449DC0()
         field_10C_health = FP_FromDouble(1.0);
     }
 
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type != -1)
         {
             sCollisions_DArray_5C1128->Raycast_417A60(
@@ -1491,7 +1491,7 @@ void Abe::Update_449DC0()
         const FP oldYPos = field_BC_ypos;
         (this->*(sAbeStateMachineTable_554910)[state_idx])();
 
-        if (field_114_flags.Get(Flags_114::e114_Bit9) || field_1AC_flags.Get(Flags_1AC::e1AC_Bit5_shrivel))
+        if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave) || field_1AC_flags.Get(Flags_1AC::e1AC_Bit5_shrivel))
         {
             return;
         }
@@ -1919,7 +1919,7 @@ void Abe::vScreenChanged_44D240()
         }
     }
 
-    if (gMap_5C3030.field_0_current_level != gMap_5C3030.field_A_level && !(field_114_flags.Get(Flags_114::e114_Bit9)))
+    if (gMap_5C3030.field_0_current_level != gMap_5C3030.field_A_level && !(field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave)))
     {
         for (char& val : sSavedKilledMudsPerPath_5C1B50.mData)
         {
@@ -1947,7 +1947,7 @@ int Abe::vGetSaveState_457110(BYTE* pSaveBuffer)
     pSaveState->field_20_g = field_D2_g;
     pSaveState->field_22_b = field_D4_b;
 
-    if (field_114_flags.Get(Flags_114::e114_Bit11))
+    if (field_114_flags.Get(Flags_114::e114_Bit11_Electrocuting))
     {
         for (int i = 0; i < gBaseGameObject_list_BB47C4->Size(); i++)
         {
@@ -2154,7 +2154,7 @@ int Abe::vGetSaveState_457110(BYTE* pSaveBuffer)
 
     pSaveState->bElectrocuted = field_114_flags.Get(Flags_114::e114_Bit7_Electrocuted);
     pSaveState->field_42_bInvisible = field_114_flags.Get(Flags_114::e114_Bit8_bInvisible);
-    pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_eBit13, sActiveHero_5C1B68->field_114_flags.Get(Flags_114::e114_Bit10));
+    pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_eBit13_teleporting, sActiveHero_5C1B68->field_114_flags.Get(Flags_114::e114_Bit10_Teleporting));
 
     pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_Bit1_lift_point_dead_while_using_lift, field_1AC_flags.Get(Flags_1AC::e1AC_Bit1_lift_point_dead_while_using_lift));
     pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_Bit2_return_to_previous_motion, field_1AC_flags.Get(Flags_1AC::e1AC_Bit2_return_to_previous_motion));
@@ -2170,7 +2170,7 @@ int Abe::vGetSaveState_457110(BYTE* pSaveBuffer)
     pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_Bit10_play_ledge_grab_sounds, field_1AC_flags.Get(Flags_1AC::e1AC_eBit13_play_ledge_grab_sounds));
     pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_Bit11_unused, field_1AC_flags.Get(Flags_1AC::e1AC_eBit14_unused));
     pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_Bit12_have_healing, field_1AC_flags.Get(Flags_1AC::e1AC_eBit15_have_healing));
-    pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_eBit13, field_114_flags.Get(Flags_114::e114_Bit10));
+    pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_eBit13_teleporting, field_114_flags.Get(Flags_114::e114_Bit10_Teleporting));
     pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_eBit14_is_mudanchee_vault_ender, field_1AC_flags.Get(Flags_1AC::e1AC_eBit16_is_mudanchee_vault_ender));
 
     pSaveState->field_D4_flags.Set(Abe_SaveState::eD4_eBit15_is_mudomo_vault_ender, field_1AE_flags.Get(Flags_1AE::e1AE_Bit1_is_mudomo_vault_ender));
@@ -2206,7 +2206,7 @@ __int16 Abe::vTakeDamage_44BB50(BaseGameObject* pFrom)
         return 0;
     }
 
-    if (field_114_flags.Get(Flags_114::e114_Bit10))
+    if (field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
     {
         return 0;
     }
@@ -3261,7 +3261,7 @@ void Abe::State_0_Idle_44EEB0()
 
             case TlvTypes::LocalWell_8:
             {
-                if (field_114_flags.Get(Flags_114::e114_Bit10))
+                if (field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
                 {
                     break;
                 }
@@ -3281,7 +3281,7 @@ void Abe::State_0_Idle_44EEB0()
 
             case TlvTypes::WellExpress_23:
             {
-                if (field_114_flags.Get(Flags_114::e114_Bit10))
+                if (field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
                 {
                     break;
                 }
@@ -5915,7 +5915,7 @@ void Abe::State_57_Dead_4589A0()
             return;
         }
 
-        if (field_10A)
+        if (field_10A_unused)
         {
             return;
         }
@@ -6180,7 +6180,7 @@ void Abe::State_67_LedgeHang_454E20()
 {
     field_E0_pShadow->field_14_flags.Set(Shadow::Flags::eBit1_ShadowAtBottom);
     const int pressed = sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_0_pressed;
-    if (sInputKey_Up_5550D8 & pressed || field_114_flags.Get(Flags_114::e114_Bit10))
+    if (sInputKey_Up_5550D8 & pressed || field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
     {
         field_106_current_motion = eAbeStates::State_65_LedgeAscend_4548E0;
     }
@@ -6286,7 +6286,7 @@ void Abe::State_69_LedgeHangWobble_454EF0()
 
     // Going up the ledge on wobble?
     const DWORD pressed = sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_0_pressed;
-    if (sInputKey_Up_5550D8 & pressed || field_114_flags.Get(Flags_114::e114_Bit10))
+    if (sInputKey_Up_5550D8 & pressed || field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
     {
         field_1AC_flags.Clear(Flags_1AC::e1AC_eBit13_play_ledge_grab_sounds);
         field_106_current_motion = eAbeStates::State_65_LedgeAscend_4548E0;
@@ -7293,7 +7293,7 @@ void Abe::State_99_LeverUse_455AC0()
 {
     if (field_20_animation.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame))
     {
-        if (field_114_flags.Get(Flags_114::e114_Bit10))
+        if (field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
         {
             field_106_current_motion = eAbeStates::State_34_DunnoBegin_44ECF0;
         }
@@ -9187,7 +9187,7 @@ __int16 Abe::RunTryEnterWell_451060()
         TlvTypes::LocalWell_8));
     if (pWellLocal)
     {
-        if (!(field_114_flags.Get(Flags_114::e114_Bit10)))
+        if (!(field_114_flags.Get(Flags_114::e114_Bit10_Teleporting)))
         {
             if ((pWellLocal->field_0_scale == 0 && field_CC_sprite_scale == FP_FromInteger(1)) ||
                 (pWellLocal->field_0_scale == 1 && field_CC_sprite_scale == FP_FromDouble(0.5)))
@@ -9208,7 +9208,7 @@ __int16 Abe::RunTryEnterWell_451060()
         TlvTypes::WellExpress_23));
     if (pWellExpress)
     {
-        if (!(field_114_flags.Get(Flags_114::e114_Bit10)))
+        if (!(field_114_flags.Get(Flags_114::e114_Bit10_Teleporting)))
         {
             if ((pWellExpress->field_0_scale == 0 && field_CC_sprite_scale == FP_FromInteger(1)) ||
                 (pWellExpress->field_0_scale == 1 && field_CC_sprite_scale == FP_FromDouble(0.5)))

--- a/Source/AliveLibAE/Abe.hpp
+++ b/Source/AliveLibAE/Abe.hpp
@@ -340,7 +340,7 @@ struct Abe_SaveState
         eD4_Bit10_play_ledge_grab_sounds = 0x200,
         eD4_Bit11_unused = 0x400,
         eD4_Bit12_have_healing = 0x800,
-        eD4_eBit13 = 0x1000, // TODO: Connects to Flags_114::e114_Bit10 in the BaseAliveGameObject class.
+        eD4_eBit13_teleporting = 0x1000,
         eD4_eBit14_is_mudanchee_vault_ender = 0x2000,
         eD4_eBit15_is_mudomo_vault_ender = 0x4000,
         eD4_eBit16_shadow_enabled = 0x8000,

--- a/Source/AliveLibAE/Alarm.hpp
+++ b/Source/AliveLibAE/Alarm.hpp
@@ -13,7 +13,7 @@ public:
     virtual void VRender(int** pOrderingTable) override;
 
     EXPORT Alarm* ctor_409300(Path_Alarm* pTlv, int tlvInfo);
-    EXPORT Alarm* ctor_4091F0(__int16 a2, __int16 switchId, __int16 a4, __int16 layer);
+    EXPORT Alarm* ctor_4091F0(__int16 durationOffset, __int16 switchId, __int16 timerOffset, __int16 layer);
 private:
     EXPORT void dtor_409380();
     EXPORT Alarm* vdtor_4092D0(signed int flags);

--- a/Source/AliveLibAE/BaseAliveGameObject.cpp
+++ b/Source/AliveLibAE/BaseAliveGameObject.cpp
@@ -59,13 +59,13 @@ EXPORT BaseAliveGameObject* BaseAliveGameObject::ctor_408240(short resourceArray
     field_114_flags.Clear(Flags_114::e114_MotionChanged_Bit2);
     field_114_flags.Clear(Flags_114::e114_Bit3_Can_Be_Possessed);
     field_114_flags.Clear(Flags_114::e114_Bit4_bPossesed);
-    field_114_flags.Clear(Flags_114::e114_Bit5);
+    field_114_flags.Clear(Flags_114::e114_Bit5_ZappedByShrykull);
     field_114_flags.Clear(Flags_114::e114_Bit6_SetOffExplosives);
     field_114_flags.Clear(Flags_114::e114_Bit7_Electrocuted);
     field_114_flags.Clear(Flags_114::e114_Bit8_bInvisible);
-    field_114_flags.Clear(Flags_114::e114_Bit9);
-    field_114_flags.Clear(Flags_114::e114_Bit10);
-    field_114_flags.Clear(Flags_114::e114_Bit11);
+    field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
+    field_114_flags.Clear(Flags_114::e114_Bit10_Teleporting);
+    field_114_flags.Clear(Flags_114::e114_Bit11_Electrocuting);
 
     field_FC_pPathTLV = nullptr;
     field_100_pCollisionLine = nullptr;
@@ -76,7 +76,7 @@ EXPORT BaseAliveGameObject* BaseAliveGameObject::ctor_408240(short resourceArray
     field_F4_previous_motion = 0;
     field_F6_anim_frame = 0;
     field_F8_LastLineYPos = FP_FromInteger(0);
-    field_10A = 0;
+    field_10A_unused = 0;
 
     gBaseAliveGameObjects_5C1B7C->Push_Back(this);
 
@@ -98,7 +98,7 @@ EXPORT void BaseAliveGameObject::dtor_4080B0()
         field_110_id = -1;
     }
 
-    if (field_10A)
+    if (field_10A_unused)
     {
         pResourceManager_5C1BB0->Shutdown_465610();
     }
@@ -264,37 +264,37 @@ void BaseAliveGameObject::vOnPathTransition_408320(__int16 cameraWorldXPos, __in
     const FP oldY = field_BC_ypos;
     switch (direction)
     {
-    case CameraPos::eCamTop_1:
-        field_B8_xpos = FP_FromInteger(cameraWorldXPos + FP_GetExponent(field_B8_xpos) % 375);
-        if (field_20_animation.field_4_flags.Get(AnimFlags::eBit22_DeadMode))
-        {
-            ALIVE_FATAL("Impossible case BaseAliveGameObject::vOnPathTransition_408320 AnimFlags::eBit22_DeadMode");
-        }
-        else
-        {
-            // TODO: This is actualy wrong !!
-            const DWORD off = field_20_animation.Get_FrameHeader_40B730(-1)->field_0_frame_header_offset;
-            field_BC_ypos = FP_FromInteger((*field_20_animation.field_20_ppBlock)[off + 5] + cameraWorldYPos + 236);
-        }
-        break;
+        case CameraPos::eCamTop_1:
+            field_B8_xpos = FP_FromInteger(cameraWorldXPos + FP_GetExponent(field_B8_xpos) % 375);
+            if (field_20_animation.field_4_flags.Get(AnimFlags::eBit22_DeadMode))
+            {
+                ALIVE_FATAL("Impossible case BaseAliveGameObject::vOnPathTransition_408320 AnimFlags::eBit22_DeadMode");
+            }
+            else
+            {
+                // TODO: This is actually wrong!!
+                const DWORD off = field_20_animation.Get_FrameHeader_40B730(-1)->field_0_frame_header_offset;
+                field_BC_ypos = FP_FromInteger((*field_20_animation.field_20_ppBlock)[off + 5] + cameraWorldYPos + 236);
+            }
+            break;
 
-    case CameraPos::eCamBottom_2:
-        field_B8_xpos = FP_FromInteger(cameraWorldXPos + FP_GetExponent(field_B8_xpos) % 375);
-        field_BC_ypos = FP_FromInteger(cameraWorldYPos + 4);
-        break;
+        case CameraPos::eCamBottom_2:
+            field_B8_xpos = FP_FromInteger(cameraWorldXPos + FP_GetExponent(field_B8_xpos) % 375);
+            field_BC_ypos = FP_FromInteger(cameraWorldYPos + 4);
+            break;
 
-    case CameraPos::eCamLeft_3:
-        field_B8_xpos = FP_FromInteger(cameraWorldXPos + (XGrid_Index_To_XPos_4498F0(field_CC_sprite_scale, MaxGridBlocks_449880(field_CC_sprite_scale) - 1)));
-        field_BC_ypos = FP_FromInteger(cameraWorldYPos + FP_GetExponent(field_BC_ypos) % 260);
-        break;
+        case CameraPos::eCamLeft_3:
+            field_B8_xpos = FP_FromInteger(cameraWorldXPos + (XGrid_Index_To_XPos_4498F0(field_CC_sprite_scale, MaxGridBlocks_449880(field_CC_sprite_scale) - 1)));
+            field_BC_ypos = FP_FromInteger(cameraWorldYPos + FP_GetExponent(field_BC_ypos) % 260);
+            break;
 
-    case CameraPos::eCamRight_4:
-        field_B8_xpos = FP_FromInteger(cameraWorldXPos + XGrid_Index_To_XPos_4498F0(field_CC_sprite_scale, 1));
-        field_BC_ypos = FP_FromInteger(cameraWorldYPos + FP_GetExponent(field_BC_ypos) % 260);
-        break;
+        case CameraPos::eCamRight_4:
+            field_B8_xpos = FP_FromInteger(cameraWorldXPos + XGrid_Index_To_XPos_4498F0(field_CC_sprite_scale, 1));
+            field_BC_ypos = FP_FromInteger(cameraWorldYPos + FP_GetExponent(field_BC_ypos) % 260);
+            break;
 
-    default:
-        break;
+        default:
+            break;
     }
 
     field_B8_xpos = FP_FromInteger(SnapToXGrid_449930(field_CC_sprite_scale, FP_GetExponent(field_B8_xpos)));
@@ -478,11 +478,11 @@ void BaseAliveGameObject::vOnTrapDoorOpen_4081F0()
     // Empty
 }
 
-signed __int16 BaseAliveGameObject::SetBaseAnimPaletteTint_425690(TintEntry * pTintArray, LevelIds level_id, int resourceID)
+signed __int16 BaseAliveGameObject::SetBaseAnimPaletteTint_425690(TintEntry* pTintArray, LevelIds level_id, int resourceID)
 {
     SetTint_425600(pTintArray, level_id);
 
-    BYTE ** pPalResource = ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Palt, resourceID, 1u, 0);
+    BYTE** pPalResource = ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Palt, resourceID, 1u, 0);
 
     if (!pPalResource)
     {
@@ -573,39 +573,39 @@ EXPORT void BaseAliveGameObject::SetActiveCameraDelayedFromDir_408C40()
      {
          switch (Is_In_Current_Camera_424A70())
          {
-         case CameraPos::eCamTop_1:
-             if (field_C8_vely < FP_FromInteger(0))
-             {
-                 gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapTop_2, this, -1);
-             }
-             break;
+             case CameraPos::eCamTop_1:
+                 if (field_C8_vely < FP_FromInteger(0))
+                 {
+                     gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapTop_2, this, -1);
+                 }
+                 break;
 
-         case CameraPos::eCamBottom_2:
-             if (field_C8_vely > FP_FromInteger(0))
-             {
-                 gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapBottom_3, this, -1);
-             }
-             break;
+             case CameraPos::eCamBottom_2:
+                 if (field_C8_vely > FP_FromInteger(0))
+                 {
+                     gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapBottom_3, this, -1);
+                 }
+                 break;
 
-         case CameraPos::eCamLeft_3:
-             if (field_C4_velx < FP_FromInteger(0))
-             {
-                 gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapLeft_0, this, -1);
-             }
-             break;
+             case CameraPos::eCamLeft_3:
+                 if (field_C4_velx < FP_FromInteger(0))
+                 {
+                     gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapLeft_0, this, -1);
+                 }
+                 break;
 
-         case CameraPos::eCamRight_4:
-             if (field_C4_velx > FP_FromInteger(0))
-             {
-                 gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapRight_1, this, -1);
-             }
-             break;
+             case CameraPos::eCamRight_4:
+                 if (field_C4_velx > FP_FromInteger(0))
+                 {
+                     gMap_5C3030.SetActiveCameraDelayed_4814A0(Map::MapDirections::eMapRight_1, this, -1);
+                 }
+                 break;
 
-         case CameraPos::eCamCurrent_0:
-         case CameraPos::eCamNone_5:
-             return;
+             case CameraPos::eCamCurrent_0:
+             case CameraPos::eCamNone_5:
+                 return;
 
-         default: return;
+             default: return;
          }
      }
 }

--- a/Source/AliveLibAE/BaseAliveGameObject.hpp
+++ b/Source/AliveLibAE/BaseAliveGameObject.hpp
@@ -22,13 +22,13 @@ enum Flags_114
     e114_MotionChanged_Bit2 = 0x2,
     e114_Bit3_Can_Be_Possessed = 0x4,
     e114_Bit4_bPossesed = 0x8,
-    e114_Bit5 = 0x10,
+    e114_Bit5_ZappedByShrykull = 0x10,
     e114_Bit6_SetOffExplosives = 0x20,
     e114_Bit7_Electrocuted = 0x40,
     e114_Bit8_bInvisible = 0x80,
-    e114_Bit9 = 0x100,
-    e114_Bit10 = 0x200,
-    e114_Bit11 = 0x400,
+    e114_Bit9_RestoredFromQuickSave = 0x100,
+    e114_Bit10_Teleporting = 0x200,
+    e114_Bit11_Electrocuting = 0x400,
 };
 
 class BaseAliveGameObject : public BaseAnimatedWithPhysicsGameObject
@@ -64,7 +64,7 @@ private:
     EXPORT BirdPortal* vIntoBirdPortal_408FD0(__int16 gridBlocks);
     EXPORT void vOnTrapDoorOpen_4081F0();
 protected:
-    EXPORT signed __int16 SetBaseAnimPaletteTint_425690(TintEntry *pTintArray, LevelIds level_id, int resourceID);
+    EXPORT signed __int16 SetBaseAnimPaletteTint_425690(TintEntry* pTintArray, LevelIds level_id, int resourceID);
 
     EXPORT BOOL Check_IsOnEndOfLine_408E90(__int16 direction, __int16 distance);
 
@@ -77,7 +77,7 @@ public:
     EXPORT __int16 MapFollowMe_408D10(__int16 snapToGrid);
 protected:
     EXPORT BOOL WallHit_408750(FP offY, FP offX);
-    EXPORT BOOL InAirCollision_408810(PathLine **ppPathLine, FP* hitX, FP* hitY, FP velY);
+    EXPORT BOOL InAirCollision_408810(PathLine** ppPathLine, FP* hitX, FP* hitY, FP velY);
     EXPORT BaseGameObject* FindObjectOfType_425180(Types typeToFind, FP xpos, FP ypos);
 public:
     EXPORT __int16 OnTrapDoorIntersection_408BA0(PlatformBase* pOther);
@@ -90,11 +90,11 @@ public:
     __int16 field_104_collision_line_type;
     __int16 field_106_current_motion;
     __int16 field_108_next_motion;
-    __int16 field_10A;
+    __int16 field_10A_unused;
     FP field_10C_health;
     int field_110_id;
     BitField16<Flags_114> field_114_flags;
-    __int16 field_116_pad;
+    __int16 field_116_padding;
 };
 ALIVE_ASSERT_SIZEOF(BaseAliveGameObject, 0x118);
 

--- a/Source/AliveLibAE/Bone.cpp
+++ b/Source/AliveLibAE/Bone.cpp
@@ -141,7 +141,7 @@ int CC Bone::CreateFromSaveState_412C10(const BYTE* pData)
     pBone->field_6_flags.Set(BaseGameObject::eDrawable_Bit4, pState->field_20_flags.Get(Bone_SaveState::eBit2_bDrawable));
     pBone->field_6_flags.Set(BaseGameObject::eInteractive_Bit8, pState->field_20_flags.Get(Bone_SaveState::eBit4_bInteractive));
 
-    pBone->field_114_flags.Set(Flags_114::e114_Bit9);
+    pBone->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
     pBone->field_128_shine_timer = sGnFrame_5C1B84;
     

--- a/Source/AliveLibAE/Electrocute.cpp
+++ b/Source/AliveLibAE/Electrocute.cpp
@@ -269,7 +269,7 @@ void Electrocute::vUpdate_4E6240()
                 field_28_b = pTargetObj->field_D4_b;
             }
             
-            pTargetObj->field_114_flags.Set(Flags_114::e114_Bit11);
+            pTargetObj->field_114_flags.Set(Flags_114::e114_Bit11_Electrocuting);
 
             pTargetObj->field_D4_b = 255;
             pTargetObj->field_D2_g = 255;
@@ -342,7 +342,7 @@ void Electrocute::vUpdate_4E6240()
                 pTargetObj->field_D2_g = field_26_g;
                 pTargetObj->field_D4_b = field_28_b;
 
-                pTargetObj->field_114_flags.Clear(Flags_114::e114_Bit11);
+                pTargetObj->field_114_flags.Clear(Flags_114::e114_Bit11_Electrocuting);
 
                 field_20_target_obj_id = -1;
                 field_44_state = 3;
@@ -397,7 +397,7 @@ void Electrocute::vStop_4E6150()
             pTarget->field_D2_g = field_26_g;
             pTarget->field_D4_b = field_28_b;
 
-            pTarget->field_114_flags.Clear(Flags_114::e114_Bit11);
+            pTarget->field_114_flags.Clear(Flags_114::e114_Bit11_Electrocuting);
         }
 
         pTarget->VTakeDamage_408730(this);

--- a/Source/AliveLibAE/Fleech.cpp
+++ b/Source/AliveLibAE/Fleech.cpp
@@ -322,7 +322,7 @@ int CC Fleech::CreateFromSaveState_42DD50(const BYTE* pBuffer)
 
     pFleech->field_F8_LastLineYPos = FP_FromInteger(pState->field_38_lastLineYPos);
 
-    pFleech->field_114_flags.Set(Flags_114::e114_Bit9);
+    pFleech->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
     pFleech->field_104_collision_line_type = pState->field_3A_line_type;
     pFleech->field_118_tlvInfo = pState->field_40_tlvInfo;
@@ -1274,9 +1274,9 @@ Fleech* Fleech::vdtor_42A140(signed int flags)
 
 void Fleech::vUpdate_42AB20()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type == -1)
         {
             field_100_pCollisionLine = nullptr;

--- a/Source/AliveLibAE/FlyingSlig.cpp
+++ b/Source/AliveLibAE/FlyingSlig.cpp
@@ -389,7 +389,7 @@ int CC FlyingSlig::CreateFromSaveState_437E40(const BYTE* pBuffer)
     pFlyingSlig->field_106_current_motion = pSaveState->field_30_current_state;
     pFlyingSlig->field_108_next_motion = pSaveState->field_32_delayed_state;
     pFlyingSlig->field_F8_LastLineYPos = FP_FromInteger(pSaveState->field_34_lastLineYPos);
-    pFlyingSlig->field_114_flags.Set(Flags_114::e114_Bit9);
+    pFlyingSlig->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
     pFlyingSlig->field_104_collision_line_type = -1;
 
     if (pSaveState->field_36_line_idx != -1)
@@ -651,9 +651,9 @@ void FlyingSlig::VUpdate()
 
 void FlyingSlig::vUpdate_434AD0()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
         if (!IsPossessed_436A90())
         {

--- a/Source/AliveLibAE/GameEnderController.cpp
+++ b/Source/AliveLibAE/GameEnderController.cpp
@@ -61,7 +61,7 @@ GameEnderController* GameEnderController::ctor_43B840()
     BaseGameObject_ctor_4DBFA0(TRUE, 0);
     SetVTable(this, 0x545198);
     field_4_typeId = Types::eGameEnderController_57;
-    field_24_state = GameEnderController_States::eState0;
+    field_24_state = GameEnderController_States::eInit_0;
     Add_Resource_4DC130(ResourceManager::Resource_Animation, AEResourceID::kDeathFlareResID);
     return this;
 }
@@ -98,7 +98,7 @@ GameEnderController* GameEnderController::vdtor_43B8D0(signed int flags)
 
 void GameEnderController::vScreenChanged_43BC80()
 {
-    if (field_24_state != GameEnderController_States::eState0)
+    if (field_24_state != GameEnderController_States::eInit_0)
     {
         if (sRescuedMudokons_5C1BC2 < 150)
         {
@@ -130,14 +130,14 @@ void GameEnderController::vUpdate_43B920()
 
     switch (field_24_state)
     {
-    case GameEnderController_States::eState0:
+    case GameEnderController_States::eInit_0:
         if (SwitchStates_Get_466020(100u))
         {
-            field_24_state = GameEnderController_States::eState1;
+            field_24_state = GameEnderController_States::eDetermineEnding_1;
         }
         break;
 
-    case GameEnderController_States::eState1:
+    case GameEnderController_States::eDetermineEnding_1:
     {
         auto pBirdPortal = static_cast<BirdPortal*>(sObjectIds_5C1B70.Find_449CF0(sActiveHero_5C1B68->field_1A8_portal_id));
         if (pBirdPortal)
@@ -168,12 +168,12 @@ void GameEnderController::vUpdate_43B920()
                     if (sRescuedMudokons_5C1BC2 >= 300)
                     {
                         gMap_5C3030.SetActiveCam_480D30(LevelIds::eBrewery_Ender_10, 1, 17, CameraSwapEffects::eEffect11, 17, 0);
-                        field_24_state = GameEnderController_States::eState5;
+                        field_24_state = GameEnderController_States::eAngelicEnding_5;
                     }
                     else
                     {
                         gMap_5C3030.SetActiveCam_480D30(LevelIds::eBrewery_Ender_10, 1, 18, CameraSwapEffects::eEffect11, 17, 0);
-                        field_24_state = GameEnderController_States::eState4;
+                        field_24_state = GameEnderController_States::eGoodEnding_4;
                     }
                 }
                 else
@@ -182,13 +182,13 @@ void GameEnderController::vUpdate_43B920()
                     {
                         gAbeBulletProof_5C1BDA = TRUE;
                         gMap_5C3030.SetActiveCam_480D30(LevelIds::eBrewery_Ender_10, 1, 15, CameraSwapEffects::eEffect11, 18, 0);
-                        field_24_state = GameEnderController_States::eState3;
+                        field_24_state = GameEnderController_States::eBadOrBlackEnding_3;
                     }
                     else
                     {
                         gAbeBulletProof_5C1BDA = FALSE;
                         gMap_5C3030.SetActiveCam_480D30(LevelIds::eBrewery_Ender_10, 1, 16, CameraSwapEffects::eEffect11, 18, 0);
-                        field_24_state = GameEnderController_States::eState3;
+                        field_24_state = GameEnderController_States::eBadOrBlackEnding_3;
                         sRescuedMudokons_5C1BC2 = sFeecoRestart_SavedMudCount_5C1BC8;
                         sKilledMudokons_5C1BC0 = sFeeco_Restart_KilledMudCount_5C1BC6;
                     }
@@ -201,36 +201,36 @@ void GameEnderController::vUpdate_43B920()
     }
     break;
 
-    case GameEnderController_States::eState3:
+    case GameEnderController_States::eBadOrBlackEnding_3:
         if (sInputObject_5BD4E0.isHeld(InputCommands::eUnPause_OrConfirm) || sInputObject_5BD4E0.isHeld(InputCommands::eBack))
         {
             gMap_5C3030.SetActiveCam_480D30(LevelIds::eFeeCoDepot_5, 1, 1, CameraSwapEffects::eEffect0_InstantChange, 0, 0);
-            field_24_state = GameEnderController_States::eState2;
+            field_24_state = GameEnderController_States::eFinish_2;
         }
         break;
 
-    case GameEnderController_States::eState4:
+    case GameEnderController_States::eGoodEnding_4:
         if (sInputObject_5BD4E0.isHeld(InputCommands::eUnPause_OrConfirm) || sInputObject_5BD4E0.isHeld(InputCommands::eBack))
         {
             gMap_5C3030.SetActiveCam_480D30(LevelIds::eCredits_16, 1, 1, CameraSwapEffects::eEffect0_InstantChange, 0, 0);
-            field_24_state = GameEnderController_States::eState2;
+            field_24_state = GameEnderController_States::eFinish_2;
         }
         break;
 
-    case GameEnderController_States::eState5:
+    case GameEnderController_States::eAngelicEnding_5:
         if (sInputObject_5BD4E0.isHeld(InputCommands::eUnPause_OrConfirm) || sInputObject_5BD4E0.isHeld(InputCommands::eBack))
         {
             gMap_5C3030.SetActiveCam_480D30(LevelIds::eBrewery_Ender_10, 1, 20, CameraSwapEffects::eEffect0_InstantChange, 0, 0);
-            field_24_state = GameEnderController_States::eState6;
+            field_24_state = GameEnderController_States::eAngelicEndingCredits_6;
         }
         break;
 
-    case GameEnderController_States::eState6:
+    case GameEnderController_States::eAngelicEndingCredits_6:
         if (sInputObject_5BD4E0.isHeld(InputCommands::eUnPause_OrConfirm) || sInputObject_5BD4E0.isHeld(InputCommands::eBack))
         {
             gMap_5C3030.SetActiveCam_480D30(LevelIds::eCredits_16, 2, 1, CameraSwapEffects::eEffect0_InstantChange, 0, 0);
             gMap_5C3030.field_CE_free_all_anim_and_palts = TRUE;
-            field_24_state = GameEnderController_States::eState2;
+            field_24_state = GameEnderController_States::eFinish_2;
         }
         break;
 

--- a/Source/AliveLibAE/GameEnderController.hpp
+++ b/Source/AliveLibAE/GameEnderController.hpp
@@ -7,26 +7,26 @@ EXPORT void CC CreateGameEnderController_43B7A0();
 
 enum class GameEnderController_States : __int16
 {
-    eState0 = 0,
-    eState1 = 1,
-    eState2 = 2,
-    eState3 = 3,
-    eState4 = 4,
-    eState5 = 5,
-    eState6 = 6,
-    eState7 = 7,
-    eState8 = 8,
-    eState9 = 9,
+    eInit_0 = 0,
+    eDetermineEnding_1 = 1,
+    eFinish_2 = 2,
+    eBadOrBlackEnding_3 = 3,
+    eGoodEnding_4 = 4,
+    eAngelicEnding_5 = 5,
+    eAngelicEndingCredits_6 = 6,
+    ePadding_7 = 7,
+    ePadding_8 = 8,
+    ePadding_9 = 9,
 };
 
 struct GameEnderController_State
 {
     Types field_0_type;
-    __int16 field_2_pad;
+    __int16 field_2_padding;
     int field_4_obj_id;
     int field_8_timer;
     GameEnderController_States field_C_state;
-    __int16 field_E_pad;
+    __int16 field_E_padding;
 };
 ALIVE_ASSERT_SIZEOF_ALWAYS(GameEnderController_State, 0x10);
 
@@ -49,7 +49,7 @@ private:
 private:
     int field_20_timer;
     GameEnderController_States field_24_state;
-    __int16 field_26_pad;
+    __int16 field_26_padding;
 };
 ALIVE_ASSERT_SIZEOF(GameEnderController, 0x28);
 

--- a/Source/AliveLibAE/Glukkon.cpp
+++ b/Source/AliveLibAE/Glukkon.cpp
@@ -227,7 +227,7 @@ signed int CC Glukkon::CreateFromSaveState_442830(const BYTE* pData)
     pGlukkon->field_106_current_motion = pSaveState->field_34_current_motion;
     pGlukkon->field_108_next_motion = pSaveState->field_36_next_motion;
     pGlukkon->field_F8_LastLineYPos = FP_FromInteger(pSaveState->field_38);
-    pGlukkon->field_114_flags.Set(Flags_114::e114_Bit9);
+    pGlukkon->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
     pGlukkon->field_1D4_timer = pSaveState->field_54;
     pGlukkon->field_104_collision_line_type = pSaveState->field_3A_line_type;
     pGlukkon->field_214_tlv_info = pSaveState->field_44_tlvInfo;
@@ -2199,9 +2199,9 @@ void Glukkon::dtor_43F570()
 
 void Glukkon::vUpdate_43F770()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type == -1)
         {
             field_100_pCollisionLine = nullptr;
@@ -2375,7 +2375,7 @@ void Glukkon::HandleInput_443BB0()
 {
     MapFollowMe_408D10(TRUE);
 
-    if (BrainIs(&Glukkon::AI_3_PlayerControlled_441A30) && field_210 == 1 && !(field_114_flags.Get(Flags_114::e114_Bit10)))
+    if (BrainIs(&Glukkon::AI_3_PlayerControlled_441A30) && field_210 == 1 && !(field_114_flags.Get(Flags_114::e114_Bit10_Teleporting)))
     {
         const auto inputHeld = sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_C_held;
         const auto matchButtons = 

--- a/Source/AliveLibAE/Grenade.cpp
+++ b/Source/AliveLibAE/Grenade.cpp
@@ -120,7 +120,7 @@ int CC Grenade::CreateFromSaveState_449410(const BYTE* pBuffer)
     pGrenade->field_6_flags.Set(BaseGameObject::eDrawable_Bit4, pState->field_20_flags.Get(Grenade_SaveState::eBit2_bDrawable));
     pGrenade->field_6_flags.Set(BaseGameObject::eInteractive_Bit8, pState->field_20_flags.Get(Grenade_SaveState::eBit4_bInteractive));
 
-    pGrenade->field_114_flags.Set(Flags_114::e114_Bit9);
+    pGrenade->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
     pGrenade->field_104_collision_line_type = pState->field_28_line_type;
     pGrenade->field_118_count = pState->field_2A_savedcount;
     pGrenade->field_120_state = pState->field_2C_state;
@@ -352,9 +352,9 @@ void Grenade::vUpdate_4489C0()
         field_6_flags.Set(BaseGameObject::eDead_Bit3);
     }
 
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type == -1)
         {
             field_100_pCollisionLine = nullptr;

--- a/Source/AliveLibAE/LaughingGas.cpp
+++ b/Source/AliveLibAE/LaughingGas.cpp
@@ -22,14 +22,14 @@ LaughingGas* LaughingGas::ctor_432400(__int16 layer, int /*notUsed*/, Path_Laugh
 
     field_4_typeId = Types::eLaughingGas_31;
     Path_LaughingGas_Data* pData = &field_48_tlv_data;
-    pData->field_0_is_laughin_gas = pTlv->field_10_is_laughing_gas;
+    pData->field_0_is_laughing_gas = pTlv->field_10_is_laughing_gas;
     pData->field_2_gas_id = pTlv->field_12_gas_id;
 
     pData->field_4_red_percent = pTlv->field_14_red_percent;
     pData->field_6_blue_percent = pTlv->field_18_blue_percent;
     pData->field_8_green_percent = pTlv->field_18_blue_percent;
 
-    if (field_48_tlv_data.field_0_is_laughin_gas)
+    if (field_48_tlv_data.field_0_is_laughing_gas)
     {
         field_36_bGreen = 1;
     }
@@ -55,18 +55,17 @@ LaughingGas* LaughingGas::ctor_432400(__int16 layer, int /*notUsed*/, Path_Laugh
     gObjList_drawables_5C1124->Push_Back(this);
     field_6_flags.Set(BaseGameObject::eDrawable_Bit4);
 
-
     field_28_y = FP_GetExponent(FP_FromInteger(pTlv->field_8_top_left.field_2_y) - pScreenManager_5BB5F4->field_20_pCamPos->field_4_y);
     field_2A_x = FP_GetExponent(PsxToPCX(FP_FromInteger(pTlv->field_8_top_left.field_0_x) - pScreenManager_5BB5F4->field_20_pCamPos->field_0_x));
 
     field_2C_h = FP_GetExponent(FP_FromInteger(pTlv->field_C_bottom_right.field_2_y) - pScreenManager_5BB5F4->field_20_pCamPos->field_4_y);
     field_2E_w = FP_GetExponent(PsxToPCX(FP_FromInteger(pTlv->field_C_bottom_right.field_0_x) - pScreenManager_5BB5F4->field_20_pCamPos->field_0_x));
-    
+
     field_31F8_w_count = (field_2E_w - field_2A_x) / 4;
     field_31FC_h_count = (field_2C_h - field_28_y + 2) / 2;
 
     field_19C_pMem = static_cast<WORD*>(ae_malloc_non_zero_4954F0(sizeof(short) * field_31FC_h_count * field_31F8_w_count));
-    
+
     Init_432980();
     VUpdate();
 
@@ -203,8 +202,9 @@ void LaughingGas::DoRender_432740()
 {
     float local_array[6];
 
-    WORD*  memPtr = field_19C_pMem;
+    WORD* memPtr = field_19C_pMem;
     int rgb_base = (1 << sRedShift_C215C4) + (1 << sGreenShift_C1D180);
+
     if (!field_36_bGreen)
     {
         rgb_base = (1 << sBlueShift_C19140) + (1 << sRedShift_C215C4) + (1 << sGreenShift_C1D180);
@@ -302,12 +302,14 @@ float LaughingGas::Calc_X_4326A0(float* a2, int xIndex)
 {
     float result = 0.0;
     float* v4 = a2 + 1;
-    for (int i=0; i<4; i++)
+
+    for (int i = 0; i < 4; i++)
     {
-        const float v5 = field_1A0_x_data[xIndex].array_4[i+1];
+        const float v5 = field_1A0_x_data[xIndex].array_4[i + 1];
         result += v5 * *v4;
         v4++;
     }
+
     return result;
 }
 
@@ -315,12 +317,14 @@ float LaughingGas::Calc_Y_4326F0(float* a2, int yIndex)
 {
     float result = 0.0;
     float* v4 = a2 + 1;
-    for (int i = 0; i<4; i++)
+
+    for (int i = 0; i < 4; i++)
     {
         const float v5 = field_24D0_y_data[yIndex].array_4[i + 1];
         result += v5 * *v4;
         v4++;
     }
+
     return result;
 }
 

--- a/Source/AliveLibAE/LaughingGas.hpp
+++ b/Source/AliveLibAE/LaughingGas.hpp
@@ -8,12 +8,12 @@
 // TODO: These can be combined
 struct Path_LaughingGas_Data
 {
-    __int16 field_0_is_laughin_gas;
+    __int16 field_0_is_laughing_gas;
     __int16 field_2_gas_id;
     __int16 field_4_red_percent;
     __int16 field_6_blue_percent;
     __int16 field_8_green_percent;
-    __int16 field_A_pad;
+    __int16 field_A_padding;
 };
 ALIVE_ASSERT_SIZEOF_ALWAYS(Path_LaughingGas_Data, 0xC);
 
@@ -24,7 +24,7 @@ struct Path_LaughingGas : public Path_TLV
     __int16 field_14_red_percent;
     __int16 field_16_green_percent;
     __int16 field_18_blue_percent;
-    __int16 field_1A;
+    __int16 field_1A_padding;
 };
 ALIVE_ASSERT_SIZEOF_ALWAYS(Path_LaughingGas, 0x1C);
 
@@ -64,23 +64,23 @@ private:
 
     EXPORT void sub_4328A0();
 private:
-    int field_20;
+    int field_20_padding;
     int field_24_tlvInfo;
     __int16 field_28_y;
     __int16 field_2A_x;
     __int16 field_2C_h;
     __int16 field_2E_w;
-    int field_30;
+    int field_30_padding;
     __int16 field_34_bEnabled;
     __int16 field_36_bGreen;
-    int field_38;
-    int field_3C;
-    int field_40;
-    int field_44;
+    int field_38_padding;
+    int field_3C_padding;
+    int field_40_padding;
+    int field_44_padding;
     Path_LaughingGas_Data field_48_tlv_data;
     FP field_54_amount_on;
     __int16 field_58_layer;
-    __int16 field_5A;
+    __int16 field_5A_padding;
 
     Prim_GasEffect field_5C_prim;
 

--- a/Source/AliveLibAE/Meat.cpp
+++ b/Source/AliveLibAE/Meat.cpp
@@ -561,7 +561,7 @@ int CC Meat::CreateFromSaveState_46A9E0(const BYTE* pBuffer)
     pMeat->field_6_flags.Set(BaseGameObject::eDrawable_Bit4, pState->field_20_flags.Get(Meat_SaveState::eBit2_bDrawable));
     pMeat->field_6_flags.Set(BaseGameObject::eInteractive_Bit8, pState->field_20_flags.Get(Meat_SaveState::eBit4_bInteractive));
 
-    pMeat->field_114_flags.Set(Flags_114::e114_Bit9);
+    pMeat->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
     pMeat->field_128_timer = sGnFrame_5C1B84;
     pMeat->field_104_collision_line_type = pState->field_28_line_type;

--- a/Source/AliveLibAE/MineCar.cpp
+++ b/Source/AliveLibAE/MineCar.cpp
@@ -296,7 +296,7 @@ int CC MineCar::CreateFromSaveState_467740(const BYTE* pBuffer)
 
     pMineCar->field_F8_LastLineYPos = FP_FromInteger(pState->field_44_last_line_ypos);
 
-    pMineCar->field_114_flags.Set(Flags_114::e114_Bit9);
+    pMineCar->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
     pMineCar->field_104_collision_line_type = pState->field_46_collision_line_type;
     pMineCar->field_118_tlvInfo = pState->field_4C_tlvInfo;
@@ -842,9 +842,9 @@ void MineCar::vUpdate_REAL_46C010()
 
 void MineCar::vUpdate_46C010()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type != -1)
         {
             sCollisions_DArray_5C1128->Raycast_417A60(

--- a/Source/AliveLibAE/Mudokon.cpp
+++ b/Source/AliveLibAE/Mudokon.cpp
@@ -446,7 +446,7 @@ Mudokon* Mudokon::ctor_474F30(Path_Mudokon* pTlv, int tlvInfo)
 
     field_DC_bApplyShadows |= 2u;
 
-    field_114_flags.Clear(Flags_114::e114_Bit9);
+    field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
     field_114_flags.Set(Flags_114::e114_Bit6_SetOffExplosives);
 
     field_18C_unused = 0;
@@ -793,7 +793,7 @@ int CC Mudokon::CreateFromSaveState_4717C0(const BYTE* pBuffer)
     pMud->field_F8_LastLineYPos = FP_FromInteger(pState->field_34_lastLineYPos);
 
     pMud->field_114_flags.Set(Flags_114::e114_Bit3_Can_Be_Possessed, pState->field_3C_can_be_possessed & 1);
-    pMud->field_114_flags.Set(Flags_114::e114_Bit9);
+    pMud->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
     pMud->field_104_collision_line_type = pState->field_36_line_type;
     pMud->field_11C_bird_portal_id = pState->field_4C_portal_id;
@@ -1002,9 +1002,9 @@ int Mudokon::vGetSaveState_47B080(Mudokon_State* pState)
 
 void Mudokon::vUpdate_4757A0()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type != -1)
         {
             sCollisions_DArray_5C1128->Raycast_417A60(

--- a/Source/AliveLibAE/NakedSlig.cpp
+++ b/Source/AliveLibAE/NakedSlig.cpp
@@ -321,7 +321,7 @@ int CC NakedSlig::CreateFromSaveState_41AE80(const BYTE* pBuffer)
     pNakedSlig->field_106_current_motion = pState->field_34_cur_motion;
     pNakedSlig->field_108_next_motion = pState->field_36_next_motion;
     pNakedSlig->field_F8_LastLineYPos = FP_FromInteger(pState->field_38_last_line_ypos);
-    pNakedSlig->field_114_flags.Set(Flags_114::e114_Bit9);
+    pNakedSlig->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
     pNakedSlig->field_1AC_timer = pState->field_54_timer;
     pNakedSlig->field_104_collision_line_type = pState->field_3A_line_type;
     pNakedSlig->field_118_tlvInfo = pState->field_44_tlvInfo;
@@ -477,9 +477,9 @@ void NakedSlig::vUpdate_419100()
     }
     else
     {
-        if (field_114_flags.Get(Flags_114::e114_Bit9))
+        if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
         {
-            field_114_flags.Clear(Flags_114::e114_Bit9);
+            field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
             if (field_104_collision_line_type == -1)
             {
                 field_100_pCollisionLine = 0;

--- a/Source/AliveLibAE/Paramite.cpp
+++ b/Source/AliveLibAE/Paramite.cpp
@@ -349,7 +349,7 @@ int CC Paramite::CreateFromSaveState_4855A0(const BYTE* pBuffer)
     pParamite->field_106_current_motion = pState->field_30_current_motion;
     pParamite->field_108_next_motion = pState->field_32_next_motion;
     pParamite->field_F8_LastLineYPos = FP_FromInteger(pState->field_34_last_line_ypos);
-    pParamite->field_114_flags.Set(Flags_114::e114_Bit9);
+    pParamite->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
     pParamite->field_104_collision_line_type = pState->field_36_line_type;
 
     pParamite->field_118_meat_id = pState->field_40_meat_id;
@@ -5172,9 +5172,9 @@ Paramite* Paramite::vdtor_487F90(signed int flags)
 
 void Paramite::vUpdate_4871B0()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type == -1)
         {
             field_100_pCollisionLine = nullptr;

--- a/Source/AliveLibAE/PauseMenu.cpp
+++ b/Source/AliveLibAE/PauseMenu.cpp
@@ -820,7 +820,7 @@ std::vector<CustomPauseMenuItem> devCheatsMenuItems({
     { "Kill All Mudokons", [](CustomPauseMenu*) { sRescuedMudokons_5C1BC2 = 0; sKilledMudokons_5C1BC0 = 300; DEV_CONSOLE_MESSAGE("(CHEAT) Killed all Mudokons", 4); }  },
     { "Give Rocks", [](CustomPauseMenu*) { sActiveHero_5C1B68->field_1A2_throwable_count = 99; DEV_CONSOLE_MESSAGE("(CHEAT) Got Bones", 4); }  },
     { "Open All Doors", [](CustomPauseMenu* pm) {  pm->ClosePauseMenu(); Cheat_OpenAllDoors(); } },
-    { "Invisible", [](CustomPauseMenu* pm) { DEV_CONSOLE_MESSAGE("(CHEAT) Invisibility!", 4);  pm->ClosePauseMenu(); sActiveHero_5C1B68->field_170_invisible_timer = 65535; sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit9);  sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit8_bInvisible); } },
+    { "Invisible", [](CustomPauseMenu* pm) { DEV_CONSOLE_MESSAGE("(CHEAT) Invisibility!", 4);  pm->ClosePauseMenu(); sActiveHero_5C1B68->field_170_invisible_timer = 65535; sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);  sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit8_bInvisible); } },
     { "Give Explosive Fart", [](CustomPauseMenu * pm) {
         DEV_CONSOLE_MESSAGE("(CHEAT) Oh man that stinks.", 4);
         pm->ClosePauseMenu();
@@ -1516,7 +1516,7 @@ void PauseMenu::Update_48FD80()
     else
     {
         pControlledChar = sControlledCharacter_5C1B8C;
-        if (!(sControlledCharacter_5C1B8C->field_114_flags.Get(e114_Bit10)))
+        if (!(sControlledCharacter_5C1B8C->field_114_flags.Get(e114_Bit10_Teleporting)))
         {
             const __int16 heroState = sActiveHero_5C1B68->field_106_current_motion;
             if (heroState != eAbeStates::State_86_HandstoneBegin_45BD00
@@ -1564,7 +1564,7 @@ void PauseMenu::Update_48FD80()
     {
         if (pHero->field_10C_health > FP_FromInteger(0)
             && !(pHero->field_114_flags.Get(Flags_114::e114_Bit7_Electrocuted))
-            && !(pControlledChar->field_114_flags.Get(Flags_114::e114_Bit10)))
+            && !(pControlledChar->field_114_flags.Get(Flags_114::e114_Bit10_Teleporting)))
         {
             const short heroState = pHero->field_106_current_motion;
             if (heroState != eAbeStates::State_86_HandstoneBegin_45BD00

--- a/Source/AliveLibAE/QuikSave.cpp
+++ b/Source/AliveLibAE/QuikSave.cpp
@@ -688,7 +688,7 @@ void CC Quicksave_ReadWorldInfo_4C9490(const Quicksave_WorldInfo* pInfo)
     // Last is read from another field
     sSavedKilledMudsPerPath_5C1B50.mData[ALIVE_COUNTOF(sSavedKilledMudsPerPath_5C1B50.mData)-1] = pInfo->field_17_last_saved_killed_muds_per_path;
 
-    sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit9);
+    sActiveHero_5C1B68->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
     sStatsSignCurrentArea_5C1A20 = pInfo->field_2C_stats_sign_current_area;
     sKilledMudokons_5C1BC0 = pInfo->field_14_killed_muds;
     sRescuedMudokons_5C1BC2 = pInfo->field_12_saved_muds;
@@ -909,10 +909,10 @@ namespace Test
         // Flags_114::e114_Bit5 not persisted
         // Flags_114::e114_Bit6_SetOffExplosives not persisted
         // Flags_114::e114_Bit7_Electrocuted not persisted
-        // Flags_114::e114_Bit8 not persisted
-        // Flags_114::e114_Bit9 not persisted
-        Compare(Flags_114::e114_Bit10, Abe_SaveState::Flags_D4::eD4_eBit13);
-        // Flags_114::e114_Bit11 will crash as it attempts to iterate the object list to find the electrocute obj but it is not persisted directly
+        // Flags_114::e114_Bit8_bInvisible not persisted
+        // Flags_114::e114_Bit9_RestoredFromQuickSave not persisted
+        Compare(Flags_114::e114_Bit10_Teleporting, Abe_SaveState::Flags_D4::eD4_eBit13_teleporting);
+        // Flags_114::e114_Bit11_Electrocuting will crash as it attempts to iterate the object list to find the electrocute obj but it is not persisted directly
         Compare(Abe::Flags_1AC::e1AC_eBit16_is_mudanchee_vault_ender, Abe_SaveState::Flags_D4::eD4_eBit14_is_mudanchee_vault_ender);
         Compare(Abe::Flags_1AE::e1AE_Bit1_is_mudomo_vault_ender, Abe_SaveState::Flags_D4::eD4_eBit15_is_mudomo_vault_ender);
         // Abe::Flags_1AE::e1AE_Bit2_bDoQuickSave not persisted

--- a/Source/AliveLibAE/Rock.cpp
+++ b/Source/AliveLibAE/Rock.cpp
@@ -353,9 +353,9 @@ void Rock::vUpdate_49E9F0()
         field_6_flags.Set(BaseGameObject::eDead_Bit3);
     }
 
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type == -1)
         {
             field_100_pCollisionLine = nullptr;
@@ -541,7 +541,7 @@ int CC Rock::CreateFromSaveState_49F720(const BYTE* pData)
     pRock->field_6_flags.Set(BaseGameObject::eDrawable_Bit4, pState->field_20_flags.Get(RockSaveState::eBit2_bDrawable));
     pRock->field_6_flags.Set(BaseGameObject::eInteractive_Bit8, pState->field_20_flags.Get(RockSaveState::eBit4_bInteractive));
 
-    pRock->field_114_flags.Set(Flags_114::e114_Bit9);
+    pRock->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
     pRock->field_128_shimmer_timer = sGnFrame_5C1B84;
 

--- a/Source/AliveLibAE/Scrab.cpp
+++ b/Source/AliveLibAE/Scrab.cpp
@@ -137,7 +137,7 @@ Scrab* Scrab::ctor_4A3C40(Path_Scrab* pTlv, int tlvInfo, __int16 spawnedScale)
 
     field_114_flags.Set(Flags_114::e114_Bit3_Can_Be_Possessed);
     field_114_flags.Set(Flags_114::e114_Bit6_SetOffExplosives);
-    field_114_flags.Clear(Flags_114::e114_Bit9);
+    field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
     field_164_prevent_depossession = 0;
     field_16C_input = 0;
@@ -366,7 +366,7 @@ int CC Scrab::CreateFromSaveState_4A70A0(const BYTE* pBuffer)
     pScrab->field_108_next_motion = pState->field_36_next_motion;
     pScrab->field_F8_LastLineYPos = FP_FromInteger(pState->field_38_last_line_ypos);
     pScrab->field_130_depossession_timer = pState->field_60_depossession_timer;
-    pScrab->field_114_flags.Set(Flags_114::e114_Bit9);
+    pScrab->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
     pScrab->field_12C_timer = pState->field_5C_timer;
     pScrab->field_104_collision_line_type = pState->field_3A_line_type;
     pScrab->field_144_tlvInfo = pState->field_44_tlvInfo;
@@ -638,9 +638,9 @@ const FP dword_546DA4[11] =
 
 void Scrab::vUpdate_4A3530()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type == -1)
         {
             field_100_pCollisionLine = nullptr;

--- a/Source/AliveLibAE/Shrykull.cpp
+++ b/Source/AliveLibAE/Shrykull.cpp
@@ -177,7 +177,7 @@ void Shrykull::vUpdate_4AEDE0()
                 break;
             }
 
-            if (CanKill_4AEC50(pObj) && !pObj->field_114_flags.Get(Flags_114::e114_Bit5))
+            if (CanKill_4AEC50(pObj) && !pObj->field_114_flags.Get(Flags_114::e114_Bit5_ZappedByShrykull))
             {
                 field_128_obj_being_zapped_id = pObj->field_8_object_id;
 
@@ -248,7 +248,7 @@ void Shrykull::vUpdate_4AEDE0()
                     FP_FromInteger((ourRect.y + ourRect.h) / 2),
                     RingTypes::eShrykull_Pulse_Large_5, field_CC_sprite_scale);
                 
-                pObj->field_114_flags.Set(Flags_114::e114_Bit5);
+                pObj->field_114_flags.Set(Flags_114::e114_Bit5_ZappedByShrykull);
 
                 SFX_Play_46FBA0(SoundEffect::ShrykullZap_18, 100, 2000);
                 SFX_Play_46FA90(SoundEffect::Zap1_49, 0);

--- a/Source/AliveLibAE/SlapLock.cpp
+++ b/Source/AliveLibAE/SlapLock.cpp
@@ -223,9 +223,9 @@ void SlapLock::vUpdate_43DF90()
     }
     else
     {
-        if (field_114_flags.Get(Flags_114::e114_Bit9))
+        if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
         {
-            field_114_flags.Clear(Flags_114::e114_Bit9);
+            field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
             if (field_118_pTlv->field_1_unknown)
             {

--- a/Source/AliveLibAE/Slig.cpp
+++ b/Source/AliveLibAE/Slig.cpp
@@ -411,7 +411,7 @@ Slig* Slig::ctor_4B1370(Path_Slig* pTlv, int tlvInfo)
     field_4_typeId = Types::eSlig_125;
 
     field_114_flags.Clear(Flags_114::e114_Bit4_bPossesed);
-    field_114_flags.Clear(Flags_114::e114_Bit9);
+    field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
     field_114_flags.Set(Flags_114::e114_Bit3_Can_Be_Possessed);
     field_114_flags.Set(Flags_114::e114_Bit6_SetOffExplosives);
 
@@ -814,7 +814,7 @@ int CC Slig::CreateFromSaveState_4B3B50(const BYTE* pBuffer)
     pSlig->field_108_next_motion = pState->field_36_next_motion;
     pSlig->field_F8_LastLineYPos = FP_FromInteger(pState->field_38_last_line_ypos);
 
-    pSlig->field_114_flags.Set(Flags_114::e114_Bit9);
+    pSlig->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
 
     pSlig->field_104_collision_line_type = pState->field_3A_collision_line_type;
     pSlig->field_11C_ai_sub_state = pState->field_42_ai_sub_state;
@@ -2289,7 +2289,7 @@ void Slig::M_PullLever_45_4B8950()
 {
     if (field_20_animation.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame))
     {
-        if (field_114_flags.Get(Flags_114::e114_Bit10))
+        if (field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
         {
             Slig_GameSpeak_SFX_4C04F0(SligSpeak::eBlurgh_11, 0, field_11E_pitch_min, this);
             field_106_current_motion = eSligMotions::M_Blurgh_31_4B5510;
@@ -4993,7 +4993,7 @@ const FP dword_547408[22] =
 
 void Slig::vUpdate_4B17C0()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
         if (field_104_collision_line_type != -1)
         {
@@ -5027,7 +5027,7 @@ void Slig::vUpdate_4B17C0()
         {
             sSligsUnderControlCount_BAF7E8++;
         }
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         field_104_collision_line_type = 0;
     }
 
@@ -5655,7 +5655,7 @@ __int16 Slig::HandlePlayerControlled_4B7800()
         }
 
         auto pSwitch = static_cast<Switch*>(FindObjectOfType_425180(Types::eLever_139, switchYPos, switchXPos));
-        if (pSwitch && !field_114_flags.Get(Flags_114::e114_Bit10))
+        if (pSwitch && !field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
         {
             pSwitch->VPull_4D6050(field_B8_xpos < pSwitch->field_B8_xpos);
             field_106_current_motion = eSligMotions::M_PullLever_45_4B8950;
@@ -5671,7 +5671,7 @@ __int16 Slig::HandlePlayerControlled_4B7800()
     {
         if (!sInputObject_5BD4E0.isPressed(sInputKey_Down_5550DC) ||
             field_CC_sprite_scale != FP_FromDouble(0.5) ||
-            field_114_flags.Get(Flags_114::e114_Bit10))
+            field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
         {
             field_106_current_motion = eSligMotions::M_Shoot_6_4B55A0;
         }
@@ -5713,7 +5713,7 @@ __int16 Slig::HandlePlayerControlled_4B7800()
 
             if (sInputObject_5BD4E0.isPressed(sInputKey_ThrowItem_5550F4) && 
                 field_CC_sprite_scale == FP_FromDouble(0.5) && 
-                !field_114_flags.Get(Flags_114::e114_Bit10))
+                !field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
             {
                 field_106_current_motion = eSligMotions::M_ShootZ_42_4B7560;
                 field_108_next_motion = -1;
@@ -6779,7 +6779,7 @@ int Slig::vGetSaveState_4BFB10(Slig_State* pState)
     pState->field_20_g = field_D2_g;
     pState->field_22_b = field_D4_b;
 
-    if (field_114_flags.Get(Flags_114::e114_Bit11))
+    if (field_114_flags.Get(Flags_114::e114_Bit11_Electrocuting))
     {
         for (int i = 0; i < gBaseGameObject_list_BB47C4->Size(); i++)
         {
@@ -7017,7 +7017,7 @@ __int16 Slig::HeardGlukkonToListenTo_4B9690(GameSpeakEvents glukkonSpeak)
 
 __int16 Slig::vTakeDamage_4B2470(BaseGameObject* pFrom)
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit10))
+    if (field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
     {
         return 0;
     }

--- a/Source/AliveLibAE/Slog.cpp
+++ b/Source/AliveLibAE/Slog.cpp
@@ -354,7 +354,7 @@ int CC Slog::CreateFromSaveState_4C54F0(const BYTE* pBuffer)
     pSlog->field_106_current_motion = pState->field_34_current_motion;
     pSlog->field_108_next_motion = pState->field_36_next_motion;
     pSlog->field_F8_LastLineYPos = FP_FromInteger(pState->field_38_last_line_ypos);
-    pSlog->field_114_flags.Set(Flags_114::e114_Bit9);
+    pSlog->field_114_flags.Set(Flags_114::e114_Bit9_RestoredFromQuickSave);
     pSlog->field_104_collision_line_type = pState->field_3A_line_type;
     pSlog->field_12C_tlvInfo = pState->field_40_tlvInfo;
     pSlog->field_118_target_id = pState->field_44_obj_id;
@@ -2938,9 +2938,9 @@ void Slog::Init_4C46A0()
 
 void Slog::vUpdate_4C50D0()
 {
-    if (field_114_flags.Get(Flags_114::e114_Bit9))
+    if (field_114_flags.Get(Flags_114::e114_Bit9_RestoredFromQuickSave))
     {
-        field_114_flags.Clear(Flags_114::e114_Bit9);
+        field_114_flags.Clear(Flags_114::e114_Bit9_RestoredFromQuickSave);
         if (field_104_collision_line_type == -1)
         {
             field_100_pCollisionLine = nullptr;

--- a/Source/AliveLibAE/Teleporter.cpp
+++ b/Source/AliveLibAE/Teleporter.cpp
@@ -161,7 +161,7 @@ void Teleporter::vUpdate_4DC400()
             return;
         }
 
-        if (sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit10))
+        if (sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit10_Teleporting))
         {
             return;
         }
@@ -170,7 +170,7 @@ void Teleporter::vUpdate_4DC400()
         field_50_objId = Teleporter::Create_ElectrocuteEffect_4DCEB0()->field_8_object_id;
 
         SFX_Play_46FBA0(SoundEffect::Zap1_49, 60, -400);
-        sControlledCharacter_5C1B8C->field_114_flags.Set(Flags_114::e114_Bit10);
+        sControlledCharacter_5C1B8C->field_114_flags.Set(Flags_114::e114_Bit10_Teleporting);
         
         SpawnRingSparks(&field_34_mTlvData);
     }
@@ -398,7 +398,7 @@ void Teleporter::vUpdate_4DC400()
 
         field_54_effect_created = 0;
         sControlledCharacter_5C1B8C->field_20_animation.field_4_flags.Set(AnimFlags::eBit3_Render);
-        sControlledCharacter_5C1B8C->field_114_flags.Clear(Flags_114::e114_Bit10);
+        sControlledCharacter_5C1B8C->field_114_flags.Clear(Flags_114::e114_Bit10_Teleporting);
         field_2C_switch_state = SwitchStates_Get_466020(field_34_mTlvData.field_1A_trigger_id);
         field_30_state = TeleporterState::eWaitForSwitchOn_0;
     }


### PR DESCRIPTION
- Named last flag in the `Abe` class.
- Named a couple of unnamed arguments in `Alarm::ctor_4091F0()`.
- Fixed alignment of the switch-case statement in `Alarm::vUpdate_409460()`.
- Named fields and flags in the `BaseAliveGameObject` class.
- Fixed alignment of switch-case statements in the `BaseAliveGameObject` class.
- Named states in the `GameEnderController` class.
- Named some fields in the `LaughingGas` class.