### PR TITLE
Adding information about License

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ https://discord.gg/khs6KKS
 ## Contributing
 If you'd like to contribute to our reverse engineering efforts, make sure to follow our reverse engineering guidelines:
 
+### License
+
+So far the code is **not** shared under any license. Once the code has been refactored and the engines merged and it no longer has roots in the original code we would feel more confident giving it a license at that point.
+
+Until then, by contributing to this repository, you agree to license your work under any of the [GPL-Compatible](https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses) licenses, which the core development team might decide to apply to this work in the future.
+
 ### IDA Guidelines
 - Use IDA 7
 - Use our git hosted IDB.


### PR DESCRIPTION
Result of discussion in Issue #1083 . Temporary solution to the licensing issue until a clear licensing is given.

GPL compatible licenses (license of Linux kernel, GIMP, LibreOffice or SuperTuxKart), are licenses that can be incorporated into code licensed under GPL. This includes public domain dedication such as  CC0, The Unlicense; permissive licenses such as [MIT license](https://opensource.org/licenses/MIT) (called [Expat License](https://directory.fsf.org/wiki/License:Expat) in GPL-compatible list), various BSD licenses, Apache License Version 2.0; the copyleft licenses such as LGPL, GPL. In short, almost any license you might want.

In the original issue I have used wording ["OSI-approved licenses"](https://opensource.org/licenses/category) instead of "GPL-Compatible license". However, the OSI-approved licenses also include licenses that have been superseded by newer versions, licenses that have been voluntarily retired and other, so I find GPL-compatible list more useful. Futhermore, it also includes CC0 unlike the [OSI-approved licenses](https://opensource.org/faq#cc-zero) list.

You might also want to specify, who is part of the "core development team" and get written agreement from all the past contributors that they agree with these  temporary licensing terms. For example such as separate Issue, to which they all simply reply "I agree that my past contribution will be licensed under these terms.".

I am **not** lawyer and this is **not** legal advice. If you have any questions regarding the best license for your code or any other legal issues relating to it, please do further research or consult with a professional.