### PR TITLE
replace add_definitions(/bigobj) with add_compile_options(/bigobj)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 
 if(MSVC)
-    add_definitions(/bigobj)
+    add_compile_options(/bigobj)
 endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
Running `CMake -> Build All` failed with error `invalid option: /bigobj`

I was able to resolve this by replacing `add_definitions(/bigobj)` with `add_compile_options(/bigobj)`.

I suggest testing on your local systems. I am running 
* VC 2017 Community - 15.9.34
* .NET Framework 4.8.04084
