### PR TITLE
Fix typo in FlyingSlig::sub_4374A0

### DIFF
--- a/Source/AliveLibAE/FlyingSlig.cpp
+++ b/Source/AliveLibAE/FlyingSlig.cpp
@@ -2214,7 +2214,7 @@ __int16 FlyingSlig::sub_4374A0(__int16 a2)
     }
     else
     {
-        if (!field_17E_flags.Get(Flags_17E::eBit11_bNoPrevLine) && (field_180_bound2 != TlvTypes::ContinuePoint_0 || !a2)) // todo: change to None when we can break abi
+        if (!field_17E_flags.Get(Flags_17E::eBit11_bNoPrevLine) && (field_180_bound2 == TlvTypes::ContinuePoint_0 || !a2)) // todo: change to None when we can break abi
         {
             if (!field_17E_flags.Get(Flags_17E::eBit3))
             {


### PR DESCRIPTION
Fixes a small typo introduced in commit d599d55b07103460af6b06dc8d2b97edd4f44967, that would cause the Flying Slig in Tunnel 2 of the Mines to never return after the chase sequence making the 4 Mudokon secret (screen MIP2C12) inaccessible.