### PR TITLE
Add support for MinGW (MSYS2) Clang builds

### DIFF
--- a/Source/AliveLibAE/CMakeLists.txt
+++ b/Source/AliveLibAE/CMakeLists.txt
@@ -415,7 +415,11 @@ target_compile_features(AliveLibAE
     PRIVATE cxx_variadic_templates)
 
 if (MINGW)
-    set(WIN32_LIBS "")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(WIN32_LIBS "imm32")
+    else()
+        set(WIN32_LIBS "")
+    endif()
 else()
     if (WIN32)
         set(WIN32_LIBS

--- a/Source/AliveLibAO/CMakeLists.txt
+++ b/Source/AliveLibAO/CMakeLists.txt
@@ -356,7 +356,12 @@ target_compile_features(AliveLibAO
     PRIVATE cxx_variadic_templates)
 
 if (MINGW)
-    set(WIN32_LIBS "")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(WIN32_LIBS "imm32")
+    else()
+        set(WIN32_LIBS "")
+    endif()
+
     set(AE_LIB AliveLibAE)
 else()
     if (WIN32)


### PR DESCRIPTION
Clang doesn't seem to implicitly link to `imm32`.