### PR TITLE
Fix some readability warnings

### DIFF
--- a/Source/AliveLibAE/Abe.cpp
+++ b/Source/AliveLibAE/Abe.cpp
@@ -896,11 +896,11 @@ Abe* Abe::ctor_44AD10(int /*frameTableOffset*/, int /*r*/, int /*g*/, int /*b*/)
         field_E0_pShadow->ctor_4AC990();
     }
 
-    
+
     // Animation test code
     //auto testAnim = ae_new<TestAnimation>();
     //testAnim->ctor();
-    
+
 
     return this;
 }
@@ -1086,7 +1086,7 @@ signed int CC Abe::CreateFromSaveState_44D4F0(const BYTE* pData)
     sActiveHero_5C1B68->field_D6_scale = pSaveState->field_1C_scale;
 
     sActiveHero_5C1B68->field_106_current_motion = pSaveState->current_motion;
-    
+
     const AnimRecord& animRec = AnimRec(sAbeFrameTables[sActiveHero_5C1B68->field_106_current_motion]);
     BYTE** animFromState = sActiveHero_5C1B68->StateToAnimResource_44AAB0(sActiveHero_5C1B68->field_106_current_motion);
     if (!animFromState)
@@ -1099,7 +1099,7 @@ signed int CC Abe::CreateFromSaveState_44D4F0(const BYTE* pData)
 
     sActiveHero_5C1B68->field_20_animation.Set_Animation_Data_409C80(animRec.mFrameTableOffset, animFromState);
     //sActiveHero_5C1B68->field_20_animation.Set_Animation_Data_409C80(sAbeFrameTables[sActiveHero_5C1B68->field_106_current_motion], animFromState);
-    
+
     sActiveHero_5C1B68->field_20_animation.field_92_current_frame = pSaveState->anim_current_frame;
     sActiveHero_5C1B68->field_20_animation.field_E_frame_change_counter = pSaveState->anim_frame_change_counter;
 
@@ -1630,7 +1630,7 @@ void Abe::Update_449DC0()
         if (field_1AC_flags.Get(Flags_1AC::e1AC_Bit2_return_to_previous_motion))
         {
             field_106_current_motion = field_F4_previous_motion;
-            
+
             const AnimRecord& animRec = AnimRec(sAbeFrameTables[field_106_current_motion]);
             field_20_animation.Set_Animation_Data_409C80(animRec.mFrameTableOffset, StateToAnimResource_44AAB0(field_106_current_motion));
             //field_20_animation.Set_Animation_Data_409C80( sAbeFrameTables[field_106_current_motion], StateToAnimResource_44AAB0(field_106_current_motion));
@@ -4483,8 +4483,8 @@ void Abe::State_23_RollLoop_453A90()
             {
                 MapFollowMe_408D10(TRUE);
 
-                if (field_C4_velx > FP_FromInteger(0) && !Input().isPressed(sInputKey_Right_5550D0) ||
-                    field_C4_velx < FP_FromInteger(0) && !Input().isPressed(sInputKey_Left_5550D4))
+                if ((field_C4_velx > FP_FromInteger(0) && !Input().isPressed(sInputKey_Right_5550D0)) ||
+                    (field_C4_velx < FP_FromInteger(0) && !Input().isPressed(sInputKey_Left_5550D4)))
                 {
                     field_106_current_motion = eAbeStates::State_17_CrouchIdle_456BC0;
                     field_C4_velx = FP_FromInteger(0);
@@ -5211,8 +5211,8 @@ void Abe::State_33_RunLoop_4508E0()
             MapFollowMe_408D10(TRUE);
 
             // Turning around?
-            if (field_C4_velx > FP_FromInteger(0) && Input().isPressed(sInputKey_Left_5550D4) ||
-                field_C4_velx < FP_FromInteger(0) && Input().isPressed(sInputKey_Right_5550D0))
+            if ((field_C4_velx > FP_FromInteger(0) && Input().isPressed(sInputKey_Left_5550D4)) ||
+                (field_C4_velx < FP_FromInteger(0) && Input().isPressed(sInputKey_Right_5550D0)))
             {
                 field_1AC_flags.Clear(Flags_1AC::e1AC_eBit14_unused);
                 field_106_current_motion = eAbeStates::State_26_RunTurn_451500;
@@ -7508,7 +7508,7 @@ void Abe::State_109_ZShotRolling_455550()
     Event_Broadcast_422BC0(kEventNoise, this);
     Event_Broadcast_422BC0(kEventSuspiciousNoise, this);
     State_3_Fall_459B60();
-    
+
     if (field_106_current_motion != eAbeStates::State_109_ZShotRolling_455550 && !gAbeBulletProof_5C1BDA)
     {
         if (field_110_id != -1)
@@ -7539,7 +7539,7 @@ void Abe::State_110_ZShot_455670()
     Event_Broadcast_422BC0(kEventNoise, this);
     Event_Broadcast_422BC0(kEventSuspiciousNoise, this);
     State_3_Fall_459B60();
-    
+
     if (field_106_current_motion != eAbeStates::State_110_ZShot_455670 && !gAbeBulletProof_5C1BDA)
     {
         if (field_110_id != -1)
@@ -8289,7 +8289,7 @@ void Abe::State_119_ToShrykull_45A990()
             field_20_animation.field_4_flags.Clear(AnimFlags::eBit2_Animate);
 
             field_120_state.raw = 1;
- 
+
             auto pShryZapper = ae_new<Shrykull>();
             if (pShryZapper)
             {
@@ -9592,7 +9592,7 @@ void Abe::BulletDamage_44C980(Bullet* pBullet)
             case ShootKind::eEverythingElse_0:
             {
                 ToKnockback_44E700(1, 1);
-                if (field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX) != pBullet->field_30_x_distance > FP_FromInteger(0))
+                if (field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX) != (pBullet->field_30_x_distance > FP_FromInteger(0)))
                 {
                     field_106_current_motion = eAbeStates::State_101_KnockForward_455420;
                 }
@@ -9615,7 +9615,7 @@ void Abe::BulletDamage_44C980(Bullet* pBullet)
             }
             case ShootKind::eRolling_2:
             {
-                if (field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX) == pBullet->field_30_x_distance > FP_FromInteger(0))
+                if (field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX) == (pBullet->field_30_x_distance > FP_FromInteger(0)))
                 {
                     field_108_next_motion = eAbeStates::State_74_RollingKnockback_455290;
                 }
@@ -10102,8 +10102,9 @@ EXPORT void CC Mudokon_SFX_457EC0(MudSounds idx, __int16 volume, int pitch, Base
             {
                 idx = MudSounds::eLaugh_10;
             }
+
+            [[fallthrough]];
         }
-        // Fall through.
         default:
         {
             auto idxToVal = static_cast<unsigned __int8>(idx);

--- a/Source/AliveLibAE/AbilityRing.cpp
+++ b/Source/AliveLibAE/AbilityRing.cpp
@@ -54,7 +54,7 @@ AbilityRing* AbilityRing::ctor_49C730(FP xpos, FP ypos, RingTypes ringType, FP s
     if (field_28_ppRes)
     {
         field_24_pRes = reinterpret_cast<AbilityRing_PolyBuffer*>(*field_28_ppRes);
-        
+
         field_24C_xpos = xpos;
         field_250_ypos = ypos;
 
@@ -85,7 +85,7 @@ AbilityRing* AbilityRing::ctor_49C730(FP xpos, FP ypos, RingTypes ringType, FP s
             {
                 r = {};
             }
-            // Fall through
+            [[fallthrough]];
 
         case RingTypes::eExplosive_Emit_Effect_2:
         case RingTypes::eInvisible_Pulse_Emit_9:
@@ -152,7 +152,7 @@ AbilityRing* AbilityRing::ctor_49C730(FP xpos, FP ypos, RingTypes ringType, FP s
         case RingTypes::eInvisible_Pulse_Small_7:
         case RingTypes::eHealing_Pulse_14:
             vSetTarget_49D140(sActiveHero_5C1B68);
-            // Fall through
+            [[fallthrough]];
 
         case RingTypes::eShrykull_Pulse_Large_5:
         case RingTypes::eShrykull_Pulse_Orange_6:
@@ -391,7 +391,7 @@ void AbilityRing::vUpdate_49D160()
         {
             CollideWithObjects_49D5E0(TRUE);
         }
-        // Fall through
+        [[fallthrough]];
 
     case RingTypes::eExplosive_Emit_Effect_2:
     case RingTypes::eInvisible_Pulse_Emit_9:
@@ -504,7 +504,7 @@ void AbilityRing::vRender_49D790(PrimHeader** ppOt)
 
         short x3 = PsxToPCX(FP_GetExponent(FP_FromInteger(field_272_screenXPos) + (field_254_left * field_260_scaleX)), 11);
         short x4 = PsxToPCX(FP_GetExponent(FP_FromInteger(field_272_screenXPos) + (field_258_right * field_260_scaleX)), 11);
-      
+
         BYTE angIncrement = 0;
         if (field_258_right <= FP_FromInteger(150))
         {

--- a/Source/AliveLibAE/Fleech.cpp
+++ b/Source/AliveLibAE/Fleech.cpp
@@ -58,7 +58,7 @@ enum eFleechMotions
     M_PatrolCry_5_42E810,
     M_Knockback_6_42EAF0,
     M_StopCrawling_7_42EBB0,
-    M_StopMidCrawlCycle_8_42EB20, 
+    M_StopMidCrawlCycle_8_42EB20,
     M_Fall_9_42ECD0,
     M_Land_10_42F330,
     M_RaiseHead_11_42F590,
@@ -627,7 +627,7 @@ void Fleech::M_Idle_3_42E850()
             FP hitY = {};
             PathLine* pLine = nullptr;
             if (field_106_current_motion == eFleechMotions::M_Idle_3_42E850 &&
-                field_20_animation.field_92_current_frame == 0 && 
+                field_20_animation.field_92_current_frame == 0 &&
                 !sCollisions_DArray_5C1128->Raycast_417A60(
                     field_B8_xpos - FP_FromInteger(5),
                     field_BC_ypos - FP_FromInteger(5),
@@ -983,7 +983,7 @@ void Fleech::M_Climb_12_42F7F0()
         }
 
         const FP pY1 = field_C8_vely + field_BC_ypos - FP_FromInteger(field_CC_sprite_scale < FP_FromInteger(1) ? 10 : 20);
-        
+
         FP pX2;
         if (xOff < FP_FromInteger(0))
         {
@@ -1080,7 +1080,7 @@ void Fleech::M_SettleOnGround_13_42FB00()
 
 void Fleech::M_ExtendTongueFromEnemy_14_42FBD0()
 {
-    if (field_11C_obj_id == sActiveHero_5C1B68->field_8_object_id && 
+    if (field_11C_obj_id == sActiveHero_5C1B68->field_8_object_id &&
         (sActiveHero_5C1B68->CantBeDamaged_44BAB0() || sActiveHero_5C1B68->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible)))
     {
         ToIdle_42E520();
@@ -1094,7 +1094,7 @@ void Fleech::M_ExtendTongueFromEnemy_14_42FBD0()
 
 void Fleech::M_RetractTongueFromEnemey_15_42FC40()
 {
-    if (sObjectIds_5C1B70.Find_449CF0(field_11C_obj_id) == sActiveHero_5C1B68 && 
+    if (sObjectIds_5C1B70.Find_449CF0(field_11C_obj_id) == sActiveHero_5C1B68 &&
         ((sActiveHero_5C1B68->CantBeDamaged_44BAB0()) || sActiveHero_5C1B68->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible)))
     {
         sub_42B8C0();
@@ -1124,10 +1124,10 @@ void Fleech::M_DeathByFalling_16_42FCE0()
         {
             pBlood->ctor_40F0B0(field_B8_xpos, field_BC_ypos - FP_FromInteger(8), FP_FromInteger(0), -FP_FromInteger(5), field_CC_sprite_scale, 50);
         }
-        
+
         Sound_430520(FleechSound::DeathByHeight_12);
         Sound_430520(FleechSound::Scared_7);
-        
+
         field_10C_health = FP_FromInteger(0);
         field_124_brain_state = eFleechBrains::eAI_Death_3_42D1E0;
         field_174_flags.Set(Flags_174::eBit3);
@@ -1373,7 +1373,7 @@ void Fleech::RenderEx_42C5A0(PrimHeader** ot)
         const __int16 camX = FP_GetExponent(camPos->field_0_x);
         const __int16 camY = FP_GetExponent(camPos->field_4_y);
 
-        tongueBlock_X[0] = FP_FromInteger(field_180_tongue_x - camX); 
+        tongueBlock_X[0] = FP_FromInteger(field_180_tongue_x - camX);
         tongueBlock_Y[0] = FP_FromInteger(field_182_tongue_y - camY);
         tongueBlock_X[4] = FP_FromInteger(field_184_target_x - camX);
         tongueBlock_Y[4] = FP_FromInteger(field_186_target_y - camY);
@@ -1609,7 +1609,7 @@ void Fleech::RenderEx_42C5A0(PrimHeader** ot)
 
 void Fleech::vScreenChanged_42A4C0()
 {
-    if (gMap_5C3030.field_0_current_level != gMap_5C3030.field_A_level || 
+    if (gMap_5C3030.field_0_current_level != gMap_5C3030.field_A_level ||
         gMap_5C3030.field_2_current_path != gMap_5C3030.field_C_path ||
         gMap_5C3030.field_22_overlayID != gMap_5C3030.GetOverlayId_480710())
     {
@@ -1738,7 +1738,7 @@ void Fleech::Init_42A170()
 {
     field_10_resources_array.SetAt(0, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, kFleechResID, TRUE, FALSE));
     field_10_resources_array.SetAt(1, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kUnknownResID_580, TRUE, FALSE));
-    
+
     Animation_Init_424E10(37704, 73, 35u, field_10_resources_array.ItemAt(0), 1, 1);
 
     field_20_animation.field_1C_fn_ptr_array = kFleech_Anim_Frame_Fns_55EFD0;
@@ -1761,9 +1761,9 @@ void Fleech::Init_42A170()
     field_11C_obj_id = -1;
     field_170_danger_obj = -1;
     field_15E = 0;
-    
+
     SetTint_425600(&stru_551844[0], gMap_5C3030.field_0_current_level);
-    
+
     if (field_CC_sprite_scale == FP_FromInteger(1))
     {
         field_20_animation.field_C_render_layer = Layer::eLayer_34;
@@ -1789,11 +1789,11 @@ void Fleech::Init_42A170()
     {
         field_BC_ypos = hitY;
     }
-    
+
     MapFollowMe_408D10(TRUE);
-    
+
     vStackOnObjectsOfType_425840(Types::eFleech_50);
-    
+
     field_E0_pShadow = ae_new<Shadow>();
     if (field_E0_pShadow)
     {
@@ -1810,7 +1810,7 @@ void Fleech::InitTonguePolys_42B6E0()
 
     field_180_tongue_x = FP_GetExponent(field_B8_xpos);
     field_182_tongue_y = FP_GetExponent(FP_FromInteger(2)*((FP_FromInteger(field_CC_sprite_scale >= FP_FromInteger(1) ? -10 : -5)) + field_BC_ypos));
-    
+
     field_178_tongue_state = 1;
 
     field_184_target_x = -1;
@@ -2025,7 +2025,7 @@ void Fleech::TongueUpdate_42BD30()
             {
             case 4:
                 field_108_next_motion = eFleechMotions::M_Consume_18_42FDF0;
-                // Fall through
+                [[fallthrough]];
             case 0:
             case 1:
             case 2:
@@ -2247,7 +2247,7 @@ __int16 Fleech::HandleEnemyStopperOrSlamDoor_42ADC0(int velX)
         FP_GetExponent(field_BC_ypos),
         TlvTypes::EnemyStopper_47));
 
-    if (pStopper && 
+    if (pStopper &&
         (pStopper->field_10_stop_direction == (nextXPos >= field_B8_xpos ? Path_EnemyStopper::StopDirection::Right_1 : Path_EnemyStopper::StopDirection::Left_0)) &&
         SwitchStates_Get_466020(pStopper->field_12_id))
     {
@@ -2272,7 +2272,7 @@ __int16 Fleech::HandleEnemyStopperOrSlamDoor_42ADC0(int velX)
         FP_GetExponent(field_BC_ypos),
         TlvTypes::SlamDoor_85));
 
-    return (pSlamDoor && 
+    return (pSlamDoor &&
         ((pSlamDoor->field_10_bStart_closed == Choice_short::eYes_1 && !SwitchStates_Get_466020(pSlamDoor->field_14_id)) ||
          (pSlamDoor->field_10_bStart_closed == Choice_short::eNo_0 && SwitchStates_Get_466020(pSlamDoor->field_14_id))));
 }
@@ -2281,7 +2281,7 @@ int Fleech::UpdateWakeUpSwitchValue_4308B0()
 {
     const __int16 curSwitchValue = static_cast<__int16>(SwitchStates_Get_466020(field_144_wake_up_id));
     const __int16 wakeUpValue = field_148_wake_up_switch_value;
-    
+
     if (curSwitchValue == wakeUpValue)
     {
         return 0;
@@ -2305,10 +2305,10 @@ __int16 Fleech::vTakeDamage_42A5C0(BaseGameObject* pFrom)
     {
         return 0;
     }
-    
+
     sub_42B8C0();
     ResetTarget_42CF70();
-    
+
     switch (pFrom->field_4_typeId)
     {
     case Types::eBullet_15:
@@ -2356,7 +2356,7 @@ __int16 Fleech::vTakeDamage_42A5C0(BaseGameObject* pFrom)
 
     case Types::eParamite_96:
         Sound_430520(FleechSound::Dismember_13);
-        // Fall through
+        [[fallthrough]];
 
     case Types::eScrab_112:
     {
@@ -2491,7 +2491,7 @@ __int16 Fleech::InRange_4307C0(BaseAliveGameObject* pObj)
     }
 
     if (FP_Abs(pObj->field_B8_xpos - field_B8_xpos) >= ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromInteger(10) ||
-        FP_Abs(pObj->field_BC_ypos - field_BC_ypos) >= ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromInteger(1) || 
+        FP_Abs(pObj->field_BC_ypos - field_BC_ypos) >= ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromInteger(1) ||
         pObj->field_CC_sprite_scale != field_CC_sprite_scale)
     {
         return FALSE;
@@ -2580,11 +2580,11 @@ BaseAliveGameObject* Fleech::FindMudOrAbe_42CFD0()
                 Math_Distance_496EB0(
                     FP_GetExponent(pObj->field_B8_xpos),
                     FP_GetExponent(pObj->field_BC_ypos),
-                    FP_GetExponent(field_B8_xpos), 
+                    FP_GetExponent(field_B8_xpos),
                     FP_GetExponent(field_BC_ypos)));
 
-            if (dist < lastDist && 
-                FP_GetExponent(field_B8_xpos) / 375 == (FP_GetExponent(pObj->field_B8_xpos) / 375) && 
+            if (dist < lastDist &&
+                FP_GetExponent(field_B8_xpos) / 375 == (FP_GetExponent(pObj->field_B8_xpos) / 375) &&
                 FP_GetExponent(field_BC_ypos) / 260 == (FP_GetExponent(pObj->field_BC_ypos) / 260))
             {
                 lastDist = dist;
@@ -2651,7 +2651,7 @@ void Fleech::MoveAlongFloor_42E600()
 
 __int16 Fleech::IsNear_428670(BaseAliveGameObject* pObj)
 {
-    if (pObj && 
+    if (pObj &&
         field_CC_sprite_scale == pObj->field_CC_sprite_scale &&
         FP_GetExponent(FP_Abs(field_B8_xpos - pObj->field_B8_xpos)) <= 750 &&
         FP_GetExponent(FP_Abs(field_BC_ypos - pObj->field_BC_ypos)) <= 260)
@@ -3433,7 +3433,7 @@ __int16 Fleech::AI_ChasingAbe_1_428760()
             field_162_hoistY = pHoist->field_8_top_left.field_2_y;
             return 14;
         }
-        // Fall through
+        [[fallthrough]];
     }
 
     case 5u:
@@ -3542,9 +3542,9 @@ __int16 Fleech::AI_ChasingAbe_1_428760()
             {
                 return field_126_state;
             }
-            
+
             ResetTarget_42CF70();
-            
+
             if (pObj->field_10C_health <= FP_FromInteger(0))
             {
                 return 13;
@@ -4245,7 +4245,7 @@ __int16 Fleech::AI_Scared_2_42D310()
             field_162_hoistY = pHoist->field_8_top_left.field_2_y;
             return 10;
         }
-        // Fall through
+        [[fallthrough]];
     }
 
     case 4u:
@@ -4373,7 +4373,7 @@ __int16 Fleech::AI_Scared_2_42D310()
             {
                 return field_126_state;
             }
-            
+
             ResetTarget_42CF70();
 
             if (pDangerObj->field_10C_health <= FP_FromInteger(0))

--- a/Source/AliveLibAE/Glukkon.cpp
+++ b/Source/AliveLibAE/Glukkon.cpp
@@ -38,7 +38,7 @@ const char* const sGlukkonMotionNames[25] =
     GLUKKON_MOTIONS_ENUM(MAKE_STRINGS)
 };
 
-const TGlukkonMotionFn sGlukkon_motion_table_5544C0[25] = 
+const TGlukkonMotionFn sGlukkon_motion_table_5544C0[25] =
 {
     &Glukkon::M_Idle_0_442D10,
     &Glukkon::M_Walk_1_442D30,
@@ -85,22 +85,22 @@ const AnimId dword_554524[4][25] =
         AnimId::Glukkon_Normal_Possessed_A, AnimId::Glukkon_Normal_Speak_A, AnimId::Glukkon_Normal_Speak_B, AnimId::Glukkon_Normal_Laugh, AnimId::Glukkon_Normal_Unknown_E,
         AnimId::Glukkon_Normal_Unknown_F, AnimId::Glukkon_Normal_Unknown_G, AnimId::Glukkon_Normal_Unknown_H, AnimId::Glukkon_Normal_Unknown_I, AnimId::Glukkon_Normal_Unknown_J,
         AnimId::Glukkon_Normal_Stand_Up_A, AnimId::Glukkon_Normal_Possessed_B, AnimId::Glukkon_Normal_Stand_Up_B, AnimId::Glukkon_Normal_Speak_C, AnimId::Glukkon_Normal_Unknown_K
-    },                       
-    {                           
+    },
+    {
         AnimId::Glukkon_Aslik_Idle, AnimId::Glukkon_Aslik_Walk, AnimId::Glukkon_Aslik_Turn_Around, AnimId::Glukkon_Aslik_Fall_Over, AnimId::Glukkon_Aslik_Jump,
         AnimId::Glukkon_Aslik_Unknown_A, AnimId::Glukkon_Aslik_Unknown_B, AnimId::Glukkon_Aslik_Unknown_C, AnimId::Glukkon_Aslik_Unknown_D, AnimId::Glukkon_Aslik_Landing,
         AnimId::Glukkon_Aslik_Possessed_A, AnimId::Glukkon_Aslik_Speak_A, AnimId::Glukkon_Aslik_Speak_B, AnimId::Glukkon_Aslik_Laugh, AnimId::Glukkon_Aslik_Unknown_E,
         AnimId::Glukkon_Aslik_Unknown_F, AnimId::Glukkon_Aslik_Unknown_G, AnimId::Glukkon_Aslik_Unknown_H, AnimId::Glukkon_Aslik_Unknown_I, AnimId::Glukkon_Aslik_Unknown_J,
         AnimId::Glukkon_Aslik_Stand_Up_A, AnimId::Glukkon_Aslik_Possessed_B, AnimId::Glukkon_Aslik_Stand_Up_B, AnimId::Glukkon_Aslik_Speak_C, AnimId::Glukkon_Aslik_Unknown_K
     },
-    {                           
+    {
         AnimId::Glukkon_Dripik_Idle, AnimId::Glukkon_Dripik_Walk, AnimId::Glukkon_Dripik_Turn_Around, AnimId::Glukkon_Dripik_Fall_Over, AnimId::Glukkon_Dripik_Jump,
         AnimId::Glukkon_Dripik_Unknown_A, AnimId::Glukkon_Dripik_Unknown_B, AnimId::Glukkon_Dripik_Unknown_C, AnimId::Glukkon_Dripik_Unknown_D, AnimId::Glukkon_Dripik_Landing,
         AnimId::Glukkon_Dripik_Possessed_A, AnimId::Glukkon_Dripik_Speak_A, AnimId::Glukkon_Dripik_Speak_B, AnimId::Glukkon_Dripik_Laugh, AnimId::Glukkon_Dripik_Unknown_E,
         AnimId::Glukkon_Dripik_Unknown_F, AnimId::Glukkon_Dripik_Unknown_G, AnimId::Glukkon_Dripik_Unknown_H, AnimId::Glukkon_Dripik_Unknown_I, AnimId::Glukkon_Dripik_Unknown_J,
         AnimId::Glukkon_Dripik_Stand_Up_A, AnimId::Glukkon_Dripik_Possessed_B, AnimId::Glukkon_Dripik_Stand_Up_B, AnimId::Glukkon_Dripik_Speak_C, AnimId::Glukkon_Dripik_Unknown_K
-    },                          
-    {                           
+    },
+    {
         AnimId::Glukkon_Phleg_Idle, AnimId::Glukkon_Phleg_Walk, AnimId::Glukkon_Phleg_Turn_Around, AnimId::Glukkon_Phleg_Fall_Over, AnimId::Glukkon_Phleg_Jump,
         AnimId::Glukkon_Phleg_Unknown_A, AnimId::Glukkon_Phleg_Unknown_B, AnimId::Glukkon_Phleg_Unknown_C, AnimId::Glukkon_Phleg_Unknown_D, AnimId::Glukkon_Phleg_Landing,
         AnimId::Glukkon_Phleg_Possessed_A, AnimId::Glukkon_Phleg_Speak_A, AnimId::Glukkon_Phleg_Speak_B, AnimId::Glukkon_Phleg_Laugh, AnimId::Glukkon_Phleg_Unknown_E,
@@ -211,7 +211,7 @@ signed int CC Glukkon::CreateFromSaveState_442830(const BYTE* pData)
 
     const AnimRecord& animRec = AnimRec(dword_554524[static_cast< int >( glukType )][pSaveState->field_28_current_motion]);
     pGlukkon->field_20_animation.Set_Animation_Data_409C80(animRec.mFrameTableOffset, nullptr);
-	
+
 	pGlukkon->field_20_animation.field_92_current_frame = pSaveState->field_2A_current_frame;
     pGlukkon->field_20_animation.field_E_frame_change_counter = pSaveState->field_2C_frame_change_counter;
     pGlukkon->field_6_flags.Set(BaseGameObject::Options::eDrawable_Bit4, pSaveState->field_2F_drawable & 1);
@@ -311,7 +311,7 @@ Glukkon* Glukkon::ctor_43F030(Path_Glukkon* pTlv, int tlvInfo)
     default:
         break;
     }
-    
+
     Init_43F260();
     return this;
 }
@@ -599,7 +599,7 @@ const FP sGlukkonJumpVelX_54539C[10] =
 void Glukkon::M_Jump_4_443030()
 {
     auto pPlatform = static_cast<PlatformBase*>(sObjectIds_5C1B70.Find_449CF0(field_110_id));
-    
+
     if (field_20_animation.field_92_current_frame >= 10)
     {
         JumpHelper();
@@ -803,7 +803,7 @@ void Glukkon::M_Fall_7_443510()
     FP hitY = {};
     PathLine* pLine = nullptr;
     const auto bCollision = InAirCollision_408810(&pLine, &hitX, &hitY, FP_FromDouble(1.8));
-    
+
     if (BrainIs(&Glukkon::AI_3_PlayerControlled_441A30))
     {
         SetActiveCameraDelayedFromDir_408C40();
@@ -821,7 +821,7 @@ void Glukkon::M_Fall_7_443510()
             field_BC_ypos = hitY;
             field_B8_xpos = hitX;
             field_C8_vely = FP_FromInteger(0);
-            
+
             GetOnPlatforms_444060();
 
             if (hitY - field_F8_LastLineYPos > (ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromInteger(7)))
@@ -893,7 +893,7 @@ void Glukkon::M_Speak1_11_4437D0()
                 Event_Broadcast_422BC0(kEventUnknown17, this);
                 field_1FC = 0;
             }
-            
+
             if (BrainIs(&Glukkon::AI_3_PlayerControlled_441A30))
             {
                 GameSpeakEvents evToBePushed;
@@ -946,7 +946,7 @@ void Glukkon::M_Speak1_11_4437D0()
             }
 
             PlaySound_GameSpeak_444AF0(field_1EA_speak, 0, 0, 0);
-            
+
             if (field_1EA_speak == GlukkonSpeak::Help_6)
             {
                 SwitchStates_Do_Operation_465F00(field_1A8_tlvData.field_18_switch_id, SwitchOp::eSetTrue_0);
@@ -1864,7 +1864,7 @@ __int16 Glukkon::AI_4_Death_442010()
                 New_Smoke_Particles_426C70(
                     (FP_FromInteger(Math_RandomRange_496AB0(-24, 24)) * field_CC_sprite_scale) + field_B8_xpos,
                     field_BC_ypos - FP_FromInteger(6),
-                    (field_CC_sprite_scale / FP_FromInteger(2)), 
+                    (field_CC_sprite_scale / FP_FromInteger(2)),
                     2, 0x80u, 0x80u, 0x80u);
 
                 SFX_Play_46FBA0(SoundEffect::Vaporize_79, 25, FP_GetExponent(FP_FromInteger(2200) * field_CC_sprite_scale));
@@ -1933,8 +1933,8 @@ __int16 Glukkon::AI_4_Death_442010()
 
     case 4:
     case 5:
-        if (!field_100_pCollisionLine || 
-            field_106_current_motion != eGlukkonMotions::M_KnockBack_3_442F40 || 
+        if (!field_100_pCollisionLine ||
+            field_106_current_motion != eGlukkonMotions::M_KnockBack_3_442F40 ||
             !(field_20_animation.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame)))
         {
             return field_210_sub_state;
@@ -2064,7 +2064,7 @@ void Glukkon::Init_43F260()
     SetTint_425600(&stru_5546B4[0], gMap_5C3030.field_0_current_level);
     field_B8_xpos = FP_FromInteger((field_1A8_tlvData.field_8_top_left.field_0_x  + field_1A8_tlvData.field_C_bottom_right.field_0_x) / 2);
     field_BC_ypos = FP_FromInteger(field_1A8_tlvData.field_8_top_left.field_2_y);
-    
+
     if (field_1A8_tlvData.field_12_start_direction == Path_Glukkon::StartDirection::eLeft_1)
     {
         field_20_animation.field_4_flags.Set(AnimFlags::eBit5_FlipX);
@@ -2256,9 +2256,9 @@ void Glukkon::vUpdate_43F770()
                 field_BC_ypos);
             VOn_TLV_Collision_4087F0(pTlv);
         }
-        
+
         Update_Slurg_WatchPoints_440600();
-        
+
         if (sControlledCharacter_5C1B8C == this && field_110_id != -1)
         {
             field_C8_vely = field_BC_ypos - field_1DC_previous_ypos;
@@ -2284,8 +2284,8 @@ void Glukkon::vPossessed_440160()
 
 void Glukkon::Update_Slurg_WatchPoints_440600()
 {
-    if (field_106_current_motion == eGlukkonMotions::M_Walk_1_442D30 || 
-        (field_106_current_motion == eGlukkonMotions::M_Jump_4_443030 && 
+    if (field_106_current_motion == eGlukkonMotions::M_Walk_1_442D30 ||
+        (field_106_current_motion == eGlukkonMotions::M_Jump_4_443030 &&
         field_20_animation.field_92_current_frame > 8))
     {
         if (sGnFrame_5C1B84 & 1)
@@ -2364,7 +2364,7 @@ void Glukkon::HandleInput_443BB0()
     if (BrainIs(&Glukkon::AI_3_PlayerControlled_441A30) && field_210_sub_state == 1 && !(field_114_flags.Get(Flags_114::e114_Bit10_Teleporting)))
     {
         const auto inputHeld = sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_C_held;
-        const auto matchButtons = 
+        const auto matchButtons =
             InputCommands::eGameSpeak1 |
             InputCommands::eGameSpeak2 |
             InputCommands::eGameSpeak3 |
@@ -2484,7 +2484,7 @@ void Glukkon::HandleInput_443BB0()
         {
             field_212_currentWalkPitch = 0;
         }
-        // Fall through
+        [[fallthrough]];
 
     case eGlukkonMotions::M_Jump_4_443030:
     case eGlukkonMotions::M_StandToJump_16_4439B0:
@@ -2786,7 +2786,7 @@ void Glukkon::FollowLine_443EB0()
         else
         {
             field_F8_LastLineYPos = field_BC_ypos;
-            
+
             VOnTrapDoorOpen();
 
             if (field_106_current_motion == eGlukkonMotions::M_Walk_1_442D30 ||
@@ -2943,9 +2943,9 @@ void Glukkon::ToDead_43F640()
 
     SwitchStates_Do_Operation_465F00(field_1A8_tlvData.field_18_switch_id, SwitchOp::eSetFalse_1);
 
-    if ((field_1A8_tlvData.field_22_glukkon_type == GlukkonTypes::Aslik_1 || 
+    if ((field_1A8_tlvData.field_22_glukkon_type == GlukkonTypes::Aslik_1 ||
          field_1A8_tlvData.field_22_glukkon_type == GlukkonTypes::Drpik_2 ||
-         field_1A8_tlvData.field_22_glukkon_type == GlukkonTypes::Phleg_3 ) && 
+         field_1A8_tlvData.field_22_glukkon_type == GlukkonTypes::Phleg_3 ) &&
         !SwitchStates_Get_466020(field_1A8_tlvData.field_26_play_movie_id))
     {
         // If an exec is dead trigger ze gas

--- a/Source/AliveLibAE/Input.cpp
+++ b/Source/AliveLibAE/Input.cpp
@@ -1992,7 +1992,7 @@ void InputObject::Update_45F040()
         {
             const DWORD command = (*field_30_pDemoRes)[field_34_demo_command_index++];
             field_3C_command = command >> 16;
-            field_40_command_duration = (sGnFrame_5C1B84 + command) & 0xFFFF;
+            field_40_command_duration = sGnFrame_5C1B84 + (command & 0xFFFF);
 
             // End demo/quit command
             if (command & 0x8000)

--- a/Source/AliveLibAE/Input.cpp
+++ b/Source/AliveLibAE/Input.cpp
@@ -1992,7 +1992,7 @@ void InputObject::Update_45F040()
         {
             const DWORD command = (*field_30_pDemoRes)[field_34_demo_command_index++];
             field_3C_command = command >> 16;
-            field_40_command_duration = sGnFrame_5C1B84 + command & 0xFFFF;
+            field_40_command_duration = (sGnFrame_5C1B84 + command) & 0xFFFF;
 
             // End demo/quit command
             if (command & 0x8000)

--- a/Source/AliveLibAE/MainMenu.cpp
+++ b/Source/AliveLibAE/MainMenu.cpp
@@ -101,7 +101,7 @@ MainMenuButton sBtnArray_Unknown_5610C0[] =
     { 0, 0, 0, 0, 0 }
 };
 
-MainMenuButton sBtnArray_Game_BackStory_Or_NewGame_561420[] = 
+MainMenuButton sBtnArray_Game_BackStory_Or_NewGame_561420[] =
 {
     { MainMenuButtonType::eCircularSelectableButton, 59, 199, 0, 13912 },  // Show me what happened
     { MainMenuButtonType::eCircularSelectableButton, 248, 199, 0, 13912 }, // Just start the game
@@ -137,7 +137,7 @@ MainMenuButton sBtnArray_PSX_1Player_Or_2Player_NewGame_5613C8[] =
 };
 
 MainMenuButton sBtnArray_Cooperative_Mode_Prompt_5613F8[] =
-{ 
+{
     { MainMenuButtonType::eCircularSelectableButton, 31, 62, 0, 13912 },   // Begin
     { MainMenuButtonType::eUnused_3, 331, 240, 0, 13912 },
     { 0, 0, 0, 0, 0 }
@@ -170,7 +170,7 @@ SfxDefinition stru_55D7C0[] =
     { 0u, 0u, 0u, 0u, 0, 0 }
 };
 
-ALIVE_ARY(1, 0x561960, MainMenuPage, 24, sMainMenuPages_561960, 
+ALIVE_ARY(1, 0x561960, MainMenuPage, 24, sMainMenuPages_561960,
 {
     { // Page 0: Controller selection menu
         MainMenuCams::eControllerSelectionCam,
@@ -181,7 +181,7 @@ ALIVE_ARY(1, 0x561960, MainMenuPage, 24, sMainMenuPages_561960,
         nullptr,
         &MainMenuController::ControllerMenu_Load_4D16B0,
         nullptr
-    }, 
+    },
     { // Page 1: Input remapping menu
         MainMenuCams::eRemapInputsCam,
         0,        0,        0,       -1,        0,
@@ -191,7 +191,7 @@ ALIVE_ARY(1, 0x561960, MainMenuPage, 24, sMainMenuPages_561960,
         nullptr,
         &MainMenuController::RemapInput_Load_4D17E0,
         nullptr
-    }, 
+    },
     { // Page 2: Dummy blank screen for quitting
         MainMenuCams::eDummyBlankCam,
         0,        0,        0,       -1,        0,
@@ -222,7 +222,7 @@ ALIVE_ARY(1, 0x561960, MainMenuPage, 24, sMainMenuPages_561960,
         nullptr,
         nullptr
     },
-    { // Page 5: Options 
+    { // Page 5: Options
         MainMenuCams::eOptionsCam,
         0,        900,      1,        0,        3,
         TRUE,
@@ -232,7 +232,7 @@ ALIVE_ARY(1, 0x561960, MainMenuPage, 24, sMainMenuPages_561960,
         nullptr,
         nullptr
     },
-    { // Page 6: Abe's motions 
+    { // Page 6: Abe's motions
         MainMenuCams::eAbesMotionKeysCam,
         0,        1600,     3,        0,        0,
         FALSE,
@@ -543,7 +543,7 @@ MainMenuController* MainMenuController::ctor_4CE9A0(Path_TLV* /*pTlv*/, TlvItemI
 {
     BaseAnimatedWithPhysicsGameObject_ctor_424930(0);
 
- 
+
     SetVTable(this, 0x547958);
     SetVTable(&field_158_animation, 0x544290);
 
@@ -586,7 +586,7 @@ MainMenuController* MainMenuController::ctor_4CE9A0(Path_TLV* /*pTlv*/, TlvItemI
     field_20_animation.field_9_g = 127;
     field_20_animation.field_8_r = 127;
 
-    
+
     field_F4_resources.field_0_resources[MenuResIds::eResHighLite] = ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, kHighliteResID, TRUE, FALSE);
     field_158_animation.Init_40A030(13912, gObjList_animations_5C1A24, this, 150, 0x41u, field_F4_resources.field_0_resources[MenuResIds::eResHighLite], 1, 0, 0);
 
@@ -680,7 +680,7 @@ MainMenuController* MainMenuController::ctor_4CE9A0(Path_TLV* /*pTlv*/, TlvItemI
         {
             ResourceManager::LoadResourceFile_49C130("ABESPEAK.BAN", reinterpret_cast<ResourceManager::TLoaderFn>(callback_4D06E0), reinterpret_cast<Camera *>(this), 0);
         }
-        
+
         pResourceManager_5C1BB0->LoadingLoop_465590(false);
         field_1FC_button_index = 0;
         field_250_selected_entry_index = sDemoIdChosenFromDemoMenu_5C1B9E;
@@ -741,7 +741,7 @@ void MainMenuController::VRender(PrimHeader** ppOt)
 void MainMenuController::Render_4CF4C0(PrimHeader** ppOt)
 {
     if (field_20_animation.field_4_flags.Get(AnimFlags::eBit2_Animate)
-        && sMainMenuPages_561960[field_214_page_index].field_E_show_character 
+        && sMainMenuPages_561960[field_214_page_index].field_E_show_character
         && field_20_animation.field_4_flags.Get(AnimFlags::eBit3_Render))
     {
         field_20_animation.vRender_40B820(184, 162, ppOt, 0, 0);
@@ -773,7 +773,7 @@ void MainMenuController::Render_4CF4C0(PrimHeader** ppOt)
 }
 
 // Main Menu Text Data
-MainMenuText sMMT_FrontPage_5623A0[1] = { 35, 205, "x", 3u, 0u, 0u, 0u,  0.75, 0u, 0u, 0u, 0u };
+MainMenuText sMMT_FrontPage_5623A0[1] = { {35, 205, "x", 3u, 0u, 0u, 0u,  0.75, 0u, 0u, 0u, 0u} };
 
 // Paramite speak text data
 const MainMenuText sParamiteSpeak_5622C8[9] =
@@ -846,9 +846,9 @@ const MainMenuText sScrabGameSpeak_562268[4] =
 const MainMenuText sAbeMotions_562448[15] =
 {
     { 55, 182, "X", 3u, 0u, 0u, 0u, 0.75, 0u, 0u, 0u, 0u },
-    { 153, 211, "esc", 3u, 0u, 0u, 0u, 0.75, 0u, 0u, 0u, 0u },            
+    { 153, 211, "esc", 3u, 0u, 0u, 0u, 0.75, 0u, 0u, 0u, 0u },
     { 175, 60, kRight, 2u, 0u, 0u, 0u, 0.88f, 0u, 0u, 0u, 0u },            //walk right arrow        //rebindables are in []
-    { 175, 79, kSneak "+ " kRight, 2u, 0u, 0u, 0u, 0.88f, 0u, 0u, 0u, 0u }, //sneak [alt] + right arrow 
+    { 175, 79, kSneak "+ " kRight, 2u, 0u, 0u, 0u, 0.88f, 0u, 0u, 0u, 0u }, //sneak [alt] + right arrow
     { 175, 98, kRun "+ " kRight, 2u, 0u, 0u, 0u, 0.88f, 0u, 0u, 0u, 0u },  //run [shift] + right arrow
     { 175, 117, kJump, 2u, 0u, 0u, 0u, 0.88f, 0u, 0u, 0u, 0u },            //jump [space]
     { 175, 136, kRun "+" kJump, 2u, 0u, 0u, 0u, 0.88f, 0u, 0u, 0u, 0u },   //runjump [shift]+[space]
@@ -918,7 +918,7 @@ MainMenuNextCam MainMenuController::AbeSpeak_Update_4D2D20(DWORD input_held)
         case InputCommands::eGameSpeak6: Set_Anim_4D05E0(AnimIds::eAbe_AllYa); break;
         case InputCommands::eGameSpeak7: Set_Anim_4D05E0(AnimIds::eAbe_Sympathy); break;
         case InputCommands::eGameSpeak8: Set_Anim_4D05E0(AnimIds::eAbe_StopIt); break;
-        case InputCommands::eBack: 
+        case InputCommands::eBack:
             Set_Anim_4D05E0(AnimIds::eAbe_GoodBye);
             // Stop chanting music
             SND_SEQ_Stop_4CAE60(SeqId::MudokonChant1_10);
@@ -1352,7 +1352,7 @@ void MainMenuController::Demo_And_FMV_List_Render_4D4F30(PrimHeader** ppOt)
                 field_258 = FP_FromInteger(0);
             }
         }
-    }    
+    }
     else if (field_254 < FP_FromInteger(0))
     {
         field_254 += field_258;
@@ -1371,7 +1371,7 @@ void MainMenuController::Demo_And_FMV_List_Render_4D4F30(PrimHeader** ppOt)
         }
     }
 
-    const MainMenuText stru_5625F8[2] = 
+    const MainMenuText stru_5625F8[2] =
     {
         { 32, 27, "x", 3u, 0u, 0u, 0u,  0.75f, 0u, 0u, 0u, 0u },
         { 331, 204, "esc", 3u, 0u, 0u, 0u,  0.75f, 0u, 0u, 0u, 0u }
@@ -1539,7 +1539,7 @@ MainMenuNextCam MainMenuController::Page_FMV_Level_Update_4D4AB0(DWORD input_hel
             FmvInfo* pFmvRecord = Path_Get_FMV_Record_460F70(v12->field_4_level_id, v12->field_A_fmv_id);
             Get_fmvs_sectors_494460(pFmvRecord->field_0_pName, 0, 0, &input_held, 0, 0);
             sLevelId_dword_5CA408 = static_cast<DWORD>(v12->field_4_level_id);
-            
+
             dword_55C128 = -1;
 
             auto pMovie = ae_new<Movie>();
@@ -1763,7 +1763,7 @@ MainMenuNextCam MainMenuController::Page_Front_Update_4D0720(DWORD input)
         field_258 = FP_FromInteger(0);
         return MainMenuNextCam(MainMenuCams::eCheatMenu_SelectFMVCam, NO_SELECTABLE_BUTTONS);
     }
-    
+
     if (sEnableCheatLevelSelect_5C1BEE)
     {
         // To level select menu
@@ -1806,9 +1806,9 @@ MainMenuNextCam MainMenuController::LoadNewGame_Update_4D0920(DWORD /*input*/)
 
             ResourceManager::FreeResource_49C330(field_F4_resources.field_0_resources[MenuResIds::eAbeSpeak]);
             field_F4_resources.field_0_resources[MenuResIds::eAbeSpeak] = nullptr;
-            
+
             ResourceManager::Reclaim_Memory_49C470(0);
-            
+
             if (!pPauseMenu_5C9300)
             {
                 pPauseMenu_5C9300 = ae_new<PauseMenu>();
@@ -1843,10 +1843,10 @@ MainMenuNextCam MainMenuController::LoadNewGame_Update_4D0920(DWORD /*input*/)
             }
 
             field_6_flags.Set(BaseGameObject::eDead_Bit3);
-            
+
             sActiveHero_5C1B68->field_B8_xpos = FP_FromInteger(0);
             sActiveHero_5C1B68->field_BC_ypos = FP_FromInteger(0);
-            
+
             Quicksave_LoadActive_4C9170();
 
             return MainMenuNextCam(MainMenuCams::eNoChange);
@@ -2560,7 +2560,7 @@ void MainMenuController::ControllerMenu_Load_4D16B0()
 }
 
 const char* sInputButtonNames_562790[8] =
-{ 
+{
     "Run",
     "Sneak",
     "Jump",
@@ -2700,7 +2700,7 @@ MainMenuNextCam MainMenuController::ControllerMenu_Update_4D16D0(DWORD input)
         Input_SaveSettingsIni_492840();
         return MainMenuNextCam(MainMenuCams::eOptionsCam);
     }
-    
+
     if (input & InputCommands::eConfigure)
     {
         // c configure controller
@@ -2910,7 +2910,7 @@ MainMenuNextCam MainMenuController::HandleGameSpeakInput(DWORD input_held, std::
     else if (input_held & InputCommands::eBack) // 0x200000
     {
         // Exit
-      
+
         field_230_target_entry_index = 8;
         field_1FC_button_index = NO_SELECTABLE_BUTTONS;
 
@@ -3093,7 +3093,7 @@ void MainMenuController::HandleMainMenuUpdate()
         {
             return;
         }
-        
+
         if (field_23C_T80.Get(Flags::eBit22_GameSpeakPlaying))
         {
             return;
@@ -3106,7 +3106,7 @@ void MainMenuController::HandleMainMenuUpdate()
 
         const MainMenuNextCam pageUpdateReturnedCam = (this->*(pPage->field_10_fn_update))(inputHeld);
 
-        if (pageUpdateReturnedCam.page_update_camera == MainMenuCams::eNoChange || 
+        if (pageUpdateReturnedCam.page_update_camera == MainMenuCams::eNoChange ||
             pageUpdateReturnedCam.page_update_camera == gMap_5C3030.field_4_current_camera)
         {
             // stay on the same screen
@@ -3559,15 +3559,15 @@ void MainMenuController::AnimationAndSoundLogic_4CFE80()
         case 9: // ??
             field_6_flags.Clear(BaseGameObject::eUpdateDuringCamSwap_Bit10);
             field_22C_T80_animation_delay = 15;
-            
+
             if (!ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kAbespeakResID, FALSE, FALSE))
             {
                 // TODO: Fix the types
-                ResourceManager::LoadResourceFile_49C130("ABESPEAK.BAN", 
-                    reinterpret_cast<ResourceManager::TLoaderFn>(callback_4D06E0), 
+                ResourceManager::LoadResourceFile_49C130("ABESPEAK.BAN",
+                    reinterpret_cast<ResourceManager::TLoaderFn>(callback_4D06E0),
                     reinterpret_cast<Camera *>(this), nullptr);
             }
-            // Fall through to next case
+            [[fallthrough]];
         case 10: // ??
             ResourceManager::FreeResource_49C330(field_F4_resources.field_0_resources[sMainMenuFrameTable_561CC8[field_220_frame_table_idx].field_4_menu_res_id]);
             field_F4_resources.field_0_resources[sMainMenuFrameTable_561CC8[field_220_frame_table_idx].field_4_menu_res_id] = nullptr;
@@ -3784,7 +3784,7 @@ void MainMenuController::AnimationAndSoundLogic_4CFE80()
                             SND_SEQ_Stop_4CAE60(SeqId::MudokonChant1_10);
                             field_23C_T80.Clear(Flags::eBit24_Chant_Seq_Playing);
                         }
-                        
+
                         field_220_frame_table_idx = field_228_res_idx;
                         field_228_res_idx = 0;
                         field_22A_anim_frame_num = 0;
@@ -3813,7 +3813,7 @@ void MainMenuController::UpdateHighliteGlow_4D0630()
 
 void MainMenuController::callback_4D06E0(MainMenuController* pMenu)
 {
-    pMenu->field_F4_resources.field_0_resources[MenuResIds::eAbeSpeak] = 
+    pMenu->field_F4_resources.field_0_resources[MenuResIds::eAbeSpeak] =
             ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kAbespeakResID, TRUE, FALSE);
 }
 
@@ -3824,7 +3824,7 @@ void MainMenuController::DrawMenuText_4D20D0(const MainMenuText* array, PrimHead
 
     char textBuffer[32] = {};
     String_FormatString_4969D0(array->field_8_text, textBuffer, ALIVE_COUNTOF(textBuffer), array->field_14 == 0);
-    
+
     if (op2)
     {
         char* plusSignIx = strchr(textBuffer, '+');

--- a/Source/AliveLibAE/Math.cpp
+++ b/Source/AliveLibAE/Math.cpp
@@ -41,7 +41,7 @@ EXPORT unsigned int  CC Math_FixedPoint_Multiply_496C50(signed int op1, signed i
     result = op2a * (op1a >> 16)
         + (unsigned __int16)op1a * (op2a >> 16)
         + ((unsigned __int16)op1a * (unsigned int)(unsigned __int16)op2a >> 16);
-    if (op1 < 0 != op2 < 0)
+    if ((op1 < 0) != (op2 < 0))
         result = -result;
     return result;
 }
@@ -73,7 +73,7 @@ EXPORT unsigned int CC Math_FixedPoint_Divide_496B70(signed int op1, signed int 
     {
         result = ((v5 << 8) % op2a << 8) / op2a + v6 + ((v5 << 8) / op2a << 8);
     }
-    if (op1a < 0 != op2 < 0)
+    if ((op1a < 0) != (op2 < 0))
         result = -result;
     return result;
 }

--- a/Source/AliveLibAE/Slig.cpp
+++ b/Source/AliveLibAE/Slig.cpp
@@ -158,7 +158,7 @@ int CC Animation_OnFrame_Slig_4C0600(void* pObj, signed __int16* pData)
     Event_Broadcast_422BC0(kEventLoudNoise, pSlig);
 
     pBullet->field_1C_update_delay = 1;
-    
+
     Dove::All_FlyAway_41FA60(0);
     return 1;
 }
@@ -394,7 +394,7 @@ Slig* Slig::ctor_4B1370(Path_Slig* pTlv, int tlvInfo)
     field_160_last_event_index = -1;
     field_176_unused = -1;
     field_174_unused = 0;
-    
+
     SetVTable(this, 0x547460);
 
     if (tlvInfo != 0xFFFF)
@@ -403,7 +403,7 @@ Slig* Slig::ctor_4B1370(Path_Slig* pTlv, int tlvInfo)
     }
 
     field_10_resources_array.SetAt(0, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgbasicResID, 1, 0));
-    
+
     const AnimRecord& rec = AnimRec(AnimId::Slig_Idle);
     BYTE** ppRes = Add_Resource_4DC130(ResourceManager::Resource_Animation, rec.mResourceId);
     Animation_Init_424E10(rec.mFrameTableOffset, rec.mMaxW, rec.mMaxH, ppRes, 1, 1);
@@ -431,11 +431,11 @@ Slig* Slig::ctor_4B1370(Path_Slig* pTlv, int tlvInfo)
     field_150_explode_timer = 0;
     field_14C_death_by_being_shot_timer = 0;
     field_FC_pPathTLV = pTlv;
-    
+
     field_218_tlv_data = *pTlv;
 
     field_110_id = -1;
-    
+
     field_106_current_motion = eSligMotions::M_Falling_7_4B42D0;
 
     field_124_return_to_previous_motion = 0;
@@ -491,11 +491,11 @@ Slig* Slig::ctor_4B1370(Path_Slig* pTlv, int tlvInfo)
     }
 
     MapFollowMe_408D10(TRUE);
-    
+
     Init_4BB0D0();
-    
+
     vStackOnObjectsOfType_425840(Types::eSlig_125);
-    
+
     if (gMap_5C3030.field_0_current_level == LevelIds::eBonewerkz_8 && gMap_5C3030.field_2_current_path == 2 && gMap_5C3030.field_4_current_camera == 5)
     {
         field_DA_xOffset = 0;
@@ -794,8 +794,8 @@ int CC Slig::CreateFromSaveState_4B3B50(const BYTE* pBuffer)
     const AnimRecord& animRec = AnimRec(sSligFrameTables_547318[pState->field_26_current_motion]);
     BYTE** ppRes = pSlig->ResForMotion_4B1E90(pSlig->field_106_current_motion);
     pSlig->field_20_animation.Set_Animation_Data_409C80(animRec.mFrameTableOffset, ppRes);
-    
-    
+
+
     pSlig->field_20_animation.field_92_current_frame = pState->field_28_current_frame;
     pSlig->field_20_animation.field_E_frame_change_counter = pState->field_2A_frame_change_counter;
 
@@ -830,7 +830,7 @@ int CC Slig::CreateFromSaveState_4B3B50(const BYTE* pBuffer)
     pSlig->field_118_tlvInfo = pState->field_5C_tlvInfo;
     pSlig->field_134_res_idx = pState->field_60_res_idx;
     pSlig->field_136_shot_motion = pState->field_62_shot_motion;
-    
+
     pSlig->field_138_zone_rect = pState->field_64_zone_rect;
 
     pSlig->field_140_unused = pState->field_6C_unused;
@@ -843,9 +843,9 @@ int CC Slig::CreateFromSaveState_4B3B50(const BYTE* pBuffer)
 
     pSlig->field_14C_death_by_being_shot_timer = pState->field_78_death_by_being_shot_timer;
     pSlig->field_150_explode_timer = pState->field_7C_explode_timer;
-    
+
     pSlig->SetBrain(sSlig_ai_table_5605AC[pState->field_80_brain_state_idx]);
-    
+
     unused_BAF7E4 = pState->field_88_unused;
 
     pSlig->field_158_num_times_to_shoot = static_cast<short>(pState->field_8C_num_times_to_shoot); // TODO: Wrong type ??
@@ -982,7 +982,7 @@ void Slig::M_Walking_2_4B5BC0()
         ToStand_4B4A20();
         return;
     }
-    
+
     MoveOnLine_4B4C40();
 
     if (field_106_current_motion == eSligMotions::M_Walking_2_4B5BC0)
@@ -1086,12 +1086,12 @@ void Slig::M_Running_4_4B6000()
         field_C4_velx = (ScaleToGridSize_4498B0(field_CC_sprite_scale) / FP_FromInteger(4));
     }
 
-    if (gMap_5C3030.GetDirection_4811A0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos) >= CameraPos::eCamCurrent_0 && 
+    if (gMap_5C3030.GetDirection_4811A0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos) >= CameraPos::eCamCurrent_0 &&
         MusicController::GetMusicType_47FDA0(0, 0, 0) != MusicController::MusicTypes::ePossessed_9)
     {
         MusicController::PlayMusic_47FD60(MusicController::MusicTypes::eChase_8, this, 0, 0);
     }
-    
+
     field_128_input |= sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_C_held;
 
     Event_Broadcast_422BC0(kEventNoise, this);
@@ -1219,13 +1219,13 @@ void Slig::M_Shoot_6_4B55A0()
                             &hitY,
                             field_D6_scale != 0 ? 6 : 96) ||
                         sCollisions_DArray_5C1128->Raycast_417A60(
-                            field_B8_xpos, 
-                            field_BC_ypos - k45Scaled, 
-                            field_B8_xpos + (k8 * (kGridSize / k8)), 
-                            field_BC_ypos - k45Scaled, 
+                            field_B8_xpos,
+                            field_BC_ypos - k45Scaled,
+                            field_B8_xpos + (k8 * (kGridSize / k8)),
+                            field_BC_ypos - k45Scaled,
                             &pLine,
-                            &hitX, 
-                            &hitY, 
+                            &hitX,
+                            &hitY,
                             field_D6_scale != 0 ? 6 : 96))
                     {
                         return;
@@ -1251,13 +1251,13 @@ void Slig::M_Shoot_6_4B55A0()
                             &hitY,
                             field_D6_scale != 0 ? 6 : 0x60) ||
                         sCollisions_DArray_5C1128->Raycast_417A60(
-                            field_B8_xpos, 
-                            field_BC_ypos - k45Scaled, 
+                            field_B8_xpos,
+                            field_BC_ypos - k45Scaled,
                             field_B8_xpos - (k8 * (kGridSize / k8)),
                             field_BC_ypos - k45Scaled,
                             &pLine,
                             &hitX,
-                            &hitY, 
+                            &hitY,
                             field_D6_scale != 0 ? 6 : 96))
                     {
                         return;
@@ -1297,12 +1297,12 @@ void Slig::M_Shoot_6_4B55A0()
                             &hitY,
                             field_D6_scale != 0 ? 6 : 96) ||
                         sCollisions_DArray_5C1128->Raycast_417A60(
-                            field_B8_xpos, field_BC_ypos - k45Scaled, 
-                            field_B8_xpos + (k8 * field_C4_velx), 
-                            field_BC_ypos - k45Scaled, 
-                            &pLine, 
-                            &hitX, 
-                            &hitY, 
+                            field_B8_xpos, field_BC_ypos - k45Scaled,
+                            field_B8_xpos + (k8 * field_C4_velx),
+                            field_BC_ypos - k45Scaled,
+                            &pLine,
+                            &hitX,
+                            &hitY,
                             field_D6_scale != 0 ? 6 : 96))
                     {
                         field_C4_velx = FP_FromInteger(0);
@@ -1939,7 +1939,7 @@ void Slig::M_Knockback_34_4B68A0()
         {
             field_C4_velx = FP_FromInteger(0);
 
-            if (field_10C_health > FP_FromInteger(0) && 
+            if (field_10C_health > FP_FromInteger(0) &&
                 field_12C_timer <= static_cast<int>(sGnFrame_5C1B84) &&
                 sActiveHero_5C1B68->field_10C_health > FP_FromInteger(0))
             {
@@ -2466,7 +2466,7 @@ void Slig::M_Beat_51_4B6C00()
                     PSX_RECT bRect = {};
                     pObj->vGetBoundingRect_424FD0(&bRect, 1);
 
-                    if (pObj->field_10C_health > FP_FromInteger(0) && 
+                    if (pObj->field_10C_health > FP_FromInteger(0) &&
                         pObj->field_D6_scale == field_D6_scale &&
                         PSX_Rects_overlap_no_adjustment(&hitRect, &bRect))
                     {
@@ -3268,13 +3268,13 @@ __int16 Slig::AI_ListenToGlukkon_IdleListen(BaseAliveGameObject* pGlukkonObj, Li
                         field_216_flags.Set(Flags_216::eBit3_GlukkonCalledAllOYa, glukkonSpeak == GameSpeakEvents::Glukkon_AllOYa_40);
                         return field_11C_ai_sub_state;
                     }
-                    
+
                     if (!FindObjectOfType_425180(Types::eMudokon_110, field_B8_xpos, field_BC_ypos - FP_FromInteger(5)))
                     {
                         const FP scaled = field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX) ?
                             -ScaleToGridSize_4498B0(field_CC_sprite_scale) :
                             ScaleToGridSize_4498B0(field_CC_sprite_scale);
-                    
+
                         if (!FindObjectOfType_425180(Types::eMudokon_110, scaled + field_B8_xpos, field_BC_ypos - FP_FromInteger(5)))
                         {
                             NextCommand_4B9A00(AI_ListeningToGlukkon_GlukkonCommands::DoitGunReload_7, AI_ListeningToGlukkon_States::LostAttention_9);
@@ -3286,7 +3286,7 @@ __int16 Slig::AI_ListenToGlukkon_IdleListen(BaseAliveGameObject* pGlukkonObj, Li
                     }
 
                     field_108_next_motion = eSligMotions::M_Beat_51_4B6C00;
-                    
+
                     field_11C_ai_sub_state = AI_ListeningToGlukkon_States::IdleListening_1;
                     field_216_flags.Set(Flags_216::eBit3_GlukkonCalledAllOYa, glukkonSpeak == GameSpeakEvents::Glukkon_AllOYa_40);
                     return field_11C_ai_sub_state;
@@ -3385,7 +3385,7 @@ __int16 Slig::AI_SpottedEnemy_7_4B3240()
         field_218_tlv_data.field_2A_chase_abe_when_spotted == Choice_short::eNo_0)
     {
         if (vOnSameYLevel_425520(sControlledCharacter_5C1B8C) &&
-            vIsObj_GettingNear_425420(sControlledCharacter_5C1B8C) && 
+            vIsObj_GettingNear_425420(sControlledCharacter_5C1B8C) &&
             vIsObjNearby_4253B0(ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromInteger(3), sControlledCharacter_5C1B8C) &&
             !Event_Get_422C00(kEventResetting) &&
             !sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible))
@@ -3394,7 +3394,7 @@ __int16 Slig::AI_SpottedEnemy_7_4B3240()
         }
         else if (
             vOnSameYLevel_425520(sControlledCharacter_5C1B8C) &&
-            Event_Get_422C00(kEventAbeOhm) && 
+            Event_Get_422C00(kEventAbeOhm) &&
             vIsFacingMe_4254A0(sControlledCharacter_5C1B8C))
         {
             ToShoot_4BF9A0();
@@ -3459,7 +3459,7 @@ __int16 Slig::AI_EnemyDead_10_4B3460()
     else
     {
         const auto rnd = Math_NextRandom();
-        
+
         // Say this often
         if (rnd < 25)
         {
@@ -3501,7 +3501,7 @@ __int16 Slig::AI_KilledEnemy_10_4B35C0()
 
 __int16 Slig::AI_PanicTurning_12_4BC490()
 {
-    if (Event_Get_422C00(kEventDeathReset) && 
+    if (Event_Get_422C00(kEventDeathReset) &&
         !gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0))
     {
         field_6_flags.Set(BaseGameObject::eDead_Bit3);
@@ -3593,7 +3593,7 @@ __int16 Slig::AI_PanicTurning_12_4BC490()
 
 __int16 Slig::AI_PanicRunning_13_4BC780()
 {
-    if (field_C4_velx > FP_FromInteger(4) && ((ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromInteger(4)) + field_B8_xpos) > FP_FromInteger(field_138_zone_rect.w)) 
+    if (field_C4_velx > FP_FromInteger(4) && ((ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromInteger(4)) + field_B8_xpos) > FP_FromInteger(field_138_zone_rect.w))
     {
         ToPanicTurn_4BC750();
     }
@@ -3613,7 +3613,7 @@ __int16 Slig::AI_PanicRunning_13_4BC780()
     {
         ToPanicRunning_4BCA30();
     }
-    else if (vOnSameYLevel_425520(sControlledCharacter_5C1B8C) && 
+    else if (vOnSameYLevel_425520(sControlledCharacter_5C1B8C) &&
         sControlledCharacter_5C1B8C->field_4_typeId != Types::eGlukkon_67 &&
         vIsFacingMe_4254A0(sControlledCharacter_5C1B8C) &&
         !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) &&
@@ -3670,7 +3670,7 @@ __int16 Slig::AI_PanicYelling_14_4BCA70()
 
         const bool kFlipX = field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX);
         field_120_timer = sGnFrame_5C1B84 + field_218_tlv_data.field_2E_panic_timeout;
-        if ((!kFlipX || field_B8_xpos >= FP_FromInteger((field_138_zone_rect.x + field_138_zone_rect.w) / 2)) && 
+        if ((!kFlipX || field_B8_xpos >= FP_FromInteger((field_138_zone_rect.x + field_138_zone_rect.w) / 2)) &&
              (kFlipX || field_B8_xpos <= FP_FromInteger((field_138_zone_rect.x + field_138_zone_rect.w) / 2)))
         {
             ToPanicRunning_4BCA30();
@@ -3704,14 +3704,14 @@ __int16 Slig::AI_Idle_15_4BD800()
     }
 
     if (vOnSameYLevel_425520(sControlledCharacter_5C1B8C) &&
-        vIsFacingMe_4254A0(sControlledCharacter_5C1B8C)  && 
+        vIsFacingMe_4254A0(sControlledCharacter_5C1B8C)  &&
         !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) &&
         !sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible) &&
-        !IsWallBetween_4BB8B0(this, sControlledCharacter_5C1B8C) && 
+        !IsWallBetween_4BB8B0(this, sControlledCharacter_5C1B8C) &&
         (!field_15E_spotted_possessed_slig || sControlledCharacter_5C1B8C->field_4_typeId != Types::eSlig_125) &&
         !IsAbeEnteringDoor_4BB990(sControlledCharacter_5C1B8C) &&
-        !Event_Get_422C00(kEventResetting) && 
-        gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) && 
+        !Event_Get_422C00(kEventResetting) &&
+        gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) &&
         sControlledCharacter_5C1B8C->field_4_typeId != Types::eGlukkon_67)
     {
         RespondToEnemyOrPatrol_4B3140();
@@ -3725,7 +3725,7 @@ __int16 Slig::AI_Idle_15_4BD800()
     }
 
     auto pShooter = static_cast<BaseAliveGameObject*>(Event_Get_422C00(kEventShooting));
-    if (pShooter && 
+    if (pShooter &&
         pShooter->field_CC_sprite_scale == field_CC_sprite_scale &&
         gMap_5C3030.Is_Point_In_Current_Camera_4810D0(pShooter->field_C2_lvl_number, pShooter->field_C0_path_number, pShooter->field_B8_xpos, pShooter->field_BC_ypos, 0) &&
         pShooter == sControlledCharacter_5C1B8C &&
@@ -3750,7 +3750,7 @@ __int16 Slig::AI_Idle_15_4BD800()
         pNoiseOrSpeaking = static_cast<BaseAliveGameObject*>(Event_Get_422C00(kEventSpeaking));
     }
 
-    if (pNoiseOrSpeaking && 
+    if (pNoiseOrSpeaking &&
         pNoiseOrSpeaking->field_CC_sprite_scale == field_CC_sprite_scale &&
         gMap_5C3030.Is_Point_In_Current_Camera_4810D0(pNoiseOrSpeaking->field_C2_lvl_number, pNoiseOrSpeaking->field_C0_path_number, pNoiseOrSpeaking->field_B8_xpos, pNoiseOrSpeaking->field_BC_ypos, 0) &&
         pNoiseOrSpeaking != this &&
@@ -3849,8 +3849,8 @@ __int16 Slig::AI_Chasing_17_4BCBD0()
     }
 
     if (field_C0_path_number != gMap_5C3030.field_2_current_path ||
-        field_C2_lvl_number != gMap_5C3030.field_0_current_level || 
-        (Event_Get_422C00(kEventDeathReset) && 
+        field_C2_lvl_number != gMap_5C3030.field_0_current_level ||
+        (Event_Get_422C00(kEventDeathReset) &&
         !gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0)))
     {
         field_6_flags.Set(BaseGameObject::eDead_Bit3);
@@ -3873,8 +3873,8 @@ __int16 Slig::AI_StartChasing_18_4BCEB0()
             field_C0_path_number,
             field_B8_xpos,
             field_BC_ypos,
-            0) && 
-            !sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible) && 
+            0) &&
+            !sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible) &&
             sControlledCharacter_5C1B8C->field_4_typeId != Types::eGlukkon_67)
         {
             field_15C_force_alive_state = 0;
@@ -3914,25 +3914,25 @@ __int16 Slig::AI_Turning_19_4BDDD0()
         ToUnderGlukkonCommand_4B9660();
         return 106;
     }
-    
-    if ((field_106_current_motion == eSligMotions::M_TurnAroundStanding_5_4B6390 && 
-        field_20_animation.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame)) || 
-        (field_106_current_motion == eSligMotions::M_StandIdle_0_4B4EC0 && 
+
+    if ((field_106_current_motion == eSligMotions::M_TurnAroundStanding_5_4B6390 &&
+        field_20_animation.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame)) ||
+        (field_106_current_motion == eSligMotions::M_StandIdle_0_4B4EC0 &&
         field_108_next_motion == -1))
     {
         WaitOrWalk_4BE870();
         return 106;
     }
-    
+
     if (field_20_animation.field_92_current_frame != 4)
     {
         ShouldStilBeAlive_4BBC00();
         return 106;
     }
-    
+
     if (field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX))
     {
-        if (sControlledCharacter_5C1B8C->field_C4_velx >= FP_FromInteger(0) && 
+        if (sControlledCharacter_5C1B8C->field_C4_velx >= FP_FromInteger(0) &&
            (sControlledCharacter_5C1B8C->field_C4_velx > FP_FromInteger(0) || sControlledCharacter_5C1B8C->field_B8_xpos >= field_B8_xpos))
         {
             ShouldStilBeAlive_4BBC00();
@@ -3941,7 +3941,7 @@ __int16 Slig::AI_Turning_19_4BDDD0()
     }
     else
     {
-        if (sControlledCharacter_5C1B8C->field_C4_velx <= FP_FromInteger(0) && 
+        if (sControlledCharacter_5C1B8C->field_C4_velx <= FP_FromInteger(0) &&
            (sControlledCharacter_5C1B8C->field_C4_velx != FP_FromInteger(0) || sControlledCharacter_5C1B8C->field_B8_xpos <= field_B8_xpos))
         {
             ShouldStilBeAlive_4BBC00();
@@ -4061,7 +4061,7 @@ __int16 Slig::AI_Walking_21_4BE0C0()
         gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) &&
         (!field_15E_spotted_possessed_slig || sControlledCharacter_5C1B8C->field_4_typeId != Types::eSlig_125) &&
         !IsAbeEnteringDoor_4BB990(sControlledCharacter_5C1B8C) &&
-        !Event_Get_422C00(kEventResetting) && 
+        !Event_Get_422C00(kEventResetting) &&
         sControlledCharacter_5C1B8C->field_4_typeId != Types::eGlukkon_67)
     {
         RespondToEnemyOrPatrol_4B3140();
@@ -4111,7 +4111,7 @@ __int16 Slig::AI_Walking_21_4BE0C0()
                 pNoiseOrSpeaker = static_cast<BaseAliveGameObject*>(Event_Get_422C00(kEventSpeaking));
             }
 
-            if (pNoiseOrSpeaker && 
+            if (pNoiseOrSpeaker &&
                 pNoiseOrSpeaker->field_CC_sprite_scale == field_CC_sprite_scale &&
                 gMap_5C3030.Is_Point_In_Current_Camera_4810D0(pNoiseOrSpeaker->field_C2_lvl_number, pNoiseOrSpeaker->field_C0_path_number, pNoiseOrSpeaker->field_B8_xpos, pNoiseOrSpeaker->field_BC_ypos, 0) &&
                 pNoiseOrSpeaker != this &&
@@ -4221,7 +4221,7 @@ __int16 Slig::AI_GetAlertedTurn_22_4BE990()
 
 __int16 Slig::AI_GetAlerted_23_4BEC40()
 {
-    if (field_120_timer != (field_218_tlv_data.field_3A_listen_time + static_cast<int>(sGnFrame_5C1B84) - 2) || 
+    if (field_120_timer != (field_218_tlv_data.field_3A_listen_time + static_cast<int>(sGnFrame_5C1B84) - 2) ||
         Math_RandomRange_496AB0(0, 100) >= field_218_tlv_data.field_3C_percent_say_what)
     {
         if (ListenToGlukkonCommands_4B95D0())
@@ -4456,7 +4456,7 @@ __int16 Slig::AI_Shooting_29_4BF750()
             sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible) ||
             IsWallBetween_4BB8B0(this, sControlledCharacter_5C1B8C) ||
             !gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) ||
-            !gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) || 
+            !gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) ||
             Event_Get_422C00(kEventResetting))
         {
             PauseALittle_4BDD00();
@@ -4469,7 +4469,7 @@ __int16 Slig::AI_Shooting_29_4BF750()
             return 111;
         }
 
-        if (!gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) && 
+        if (!gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) &&
             field_218_tlv_data.field_2A_chase_abe_when_spotted == Choice_short::eYes_1)
         {
             ToChase_4BCFF0();
@@ -4517,10 +4517,10 @@ __int16 Slig::AI_Inactive_32_4B9430()
         else if (vOnSameYLevel_425520(sControlledCharacter_5C1B8C) &&
                  vIsFacingMe_4254A0(sControlledCharacter_5C1B8C) &&
                  vIsObjNearby_4253B0(ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromInteger(1), sControlledCharacter_5C1B8C) &&
-                 !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) && 
+                 !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) &&
                  !sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible) &&
                  !IsWallBetween_4BB8B0(this, sControlledCharacter_5C1B8C) &&
-                 !Event_Get_422C00(kEventResetting) && 
+                 !Event_Get_422C00(kEventResetting) &&
                  sControlledCharacter_5C1B8C->field_4_typeId != Types::eGlukkon_67)
         {
             ToShoot_4BF9A0();
@@ -4547,12 +4547,12 @@ __int16 Slig::AI_Paused_33_4B8DD0()
 
     if (vOnSameYLevel_425520(sControlledCharacter_5C1B8C) &&
         vIsFacingMe_4254A0(sControlledCharacter_5C1B8C) &&
-        !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) && 
+        !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) &&
         !sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible) &&
         !IsWallBetween_4BB8B0(this, sControlledCharacter_5C1B8C) &&
         gMap_5C3030.Is_Point_In_Current_Camera_4810D0(field_C2_lvl_number, field_C0_path_number, field_B8_xpos, field_BC_ypos, 0) &&
         (!field_15E_spotted_possessed_slig || sControlledCharacter_5C1B8C->field_4_typeId != Types::eSlig_125) &&
-        !Event_Get_422C00(kEventResetting) && 
+        !Event_Get_422C00(kEventResetting) &&
         sControlledCharacter_5C1B8C->field_4_typeId != Types::eGlukkon_67
         )
     {
@@ -4584,13 +4584,13 @@ __int16 Slig::AI_Paused_33_4B8DD0()
         }
 
         if (pNoiseOrSpeaking &&
-            pNoiseOrSpeaking->field_CC_sprite_scale == field_CC_sprite_scale && 
-            pNoiseOrSpeaking != this && field_120_timer <= static_cast<int>(sGnFrame_5C1B84) && 
+            pNoiseOrSpeaking->field_CC_sprite_scale == field_CC_sprite_scale &&
+            pNoiseOrSpeaking != this && field_120_timer <= static_cast<int>(sGnFrame_5C1B84) &&
             !Event_Get_422C00(kEventResetting))
         {
             ToTurn_4BE090();
         }
-        else if (sControlledCharacter_5C1B8C->field_CC_sprite_scale > field_CC_sprite_scale && 
+        else if (sControlledCharacter_5C1B8C->field_CC_sprite_scale > field_CC_sprite_scale &&
             vIsFacingMe_4254A0(sControlledCharacter_5C1B8C) &&
             !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) &&
             !sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible) &&
@@ -4707,7 +4707,7 @@ void Slig::Init_4BB0D0()
     field_10_resources_array.SetAt(12, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kShellResID, 1, 0));
     field_10_resources_array.SetAt(2, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation,  ResourceID::kSlgknbkResID, 1, 0));
     field_10_resources_array.SetAt(16, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSquibSmokeResID, 1, 0));
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 0x80))
     {
         field_10_resources_array.SetAt(6, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgknfdResID, 1, 0));
@@ -4717,42 +4717,42 @@ void Slig::Init_4BB0D0()
     {
         field_10_resources_array.SetAt(3, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgedgeResID, 1, 0));
     }
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 1))
     {
         field_10_resources_array.SetAt(7, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgleverResID, 1, 0));
     }
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 2))
     {
         field_10_resources_array.SetAt(8, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgliftResID, 1, 0));
     }
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 0x200))
     {
         field_10_resources_array.SetAt(4, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgsmashResID, 1, 0));
     }
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 0x400))
     {
         field_10_resources_array.SetAt(9, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgbeatResID, 1, 0));
     }
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 4))
     {
         field_10_resources_array.SetAt(5, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgzshotResID, 1, 0));
     }
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 0x40))
     {
         field_10_resources_array.SetAt(1, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kSlgsleepResID, 1, 0));
     }
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 8))
     {
         field_10_resources_array.SetAt(13, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kZflashResID, 1, 0));
     }
-    
+
     if (!(field_218_tlv_data.field_48_disable_resources & 0x10))
     {
         field_10_resources_array.SetAt(15, ResourceManager::GetLoadedResource_49C2A0(ResourceManager::Resource_Animation, ResourceID::kAbeknokzResID, 1, 0));
@@ -4837,7 +4837,7 @@ void Slig::Init_4BB0D0()
     {
         field_20_animation.field_4_flags.Set(AnimFlags::eBit5_FlipX);
     }
-   
+
     field_290_points_count = 0;
 
     field_268_points[field_290_points_count].field_0_x = FP_GetExponent(field_B8_xpos);
@@ -4899,7 +4899,7 @@ void Slig::dtor_4B1CF0()
     if (sControlledCharacter_5C1B8C == this)
     {
         sControlledCharacter_5C1B8C = sActiveHero_5C1B68;
-        
+
         MusicController::PlayMusic_47FD60(MusicController::MusicTypes::eNone_0, this, 0, 0);
 
         if (gMap_5C3030.field_A_level != LevelIds::eMenu_0)
@@ -4946,7 +4946,7 @@ Slig* Slig::vdtor_4B1790(signed int flags)
 }
 
 const FP dword_5473E8[8] =
-{ 
+{
     FP_FromInteger(4),
     FP_FromInteger(4),
     FP_FromInteger(0),
@@ -5043,7 +5043,7 @@ void Slig::vUpdate_4B17C0()
         {
             field_C4_velx = dword_5473E8[sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_4_dir >> 5];
             field_C8_vely = dword_547408[sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_4_dir >> 5];
-            
+
             if (sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_0_pressed & 0x10)
             {
                 field_C4_velx += dword_5473E8[sInputObject_5BD4E0.field_0_pads[sCurrentControllerIndex_5C1BBE].field_4_dir >> 5];
@@ -5136,7 +5136,7 @@ void Slig::vUpdate_4B17C0()
 
 void Slig::vScreenChanged_4B1E20()
 {
-    if (gMap_5C3030.field_0_current_level != gMap_5C3030.field_A_level || 
+    if (gMap_5C3030.field_0_current_level != gMap_5C3030.field_A_level ||
         gMap_5C3030.field_22_overlayID != gMap_5C3030.GetOverlayId_480710() ||
         (gMap_5C3030.field_2_current_path != gMap_5C3030.field_C_path && this != sControlledCharacter_5C1B8C))
     {
@@ -5591,8 +5591,8 @@ __int16 Slig::LeftRigtMovement(MovementDirection direction)
         break;
     }
 
-    if (direction == MovementDirection::eLeft && !field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX) ||
-        direction == MovementDirection::eRight && field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX))
+    if ((direction == MovementDirection::eLeft && !field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX)) ||
+        (direction == MovementDirection::eRight && field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX)))
     {
         field_106_current_motion = eSligMotions::M_TurnAroundStanding_5_4B6390;
         return 1;
@@ -5867,7 +5867,7 @@ __int16 Slig::GetNextMotionIncGameSpeak_4B5080(int input)
         case eSligMotions::M_SpeakAIFreeze_30_4B54F0:   speak = SligSpeak::eFreeze_8;    break;
         case eSligMotions::M_Blurgh_31_4B5510:          speak = SligSpeak::eBlurgh_11;    break;
         }
- 
+
         Slig_GameSpeak_SFX_4C04F0(speak, 0, field_11E_pitch_min, this);
         field_106_current_motion = field_108_next_motion;
         field_108_next_motion = -1;
@@ -5934,9 +5934,9 @@ BOOL Slig::IsWallBetween_4BB8B0(BaseAliveGameObject* pLeft, BaseAliveGameObject*
     FP hitX = {};
     FP hitY = {};
     return sCollisions_DArray_5C1128->Raycast_417A60(
-        pLeft->field_B8_xpos, 
+        pLeft->field_B8_xpos,
         FP_FromInteger(thisBRect.h - 25),
-        pRight->field_B8_xpos, 
+        pRight->field_B8_xpos,
         FP_FromInteger(rightBRect.h -25),
         &pLine, &hitX, &hitY, pLeft->field_D6_scale != 0 ? 6 : 0x60) == 1;
 }
@@ -6069,8 +6069,8 @@ void Slig::FallKnockBackOrSmash_4B4A90()
 
 void Slig::TurnOrSayWhat_4BEBC0()
 {
-    if (Event_Get_422C00(kEventSpeaking) && 
-        !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) && 
+    if (Event_Get_422C00(kEventSpeaking) &&
+        !IsInInvisibleZone_425710(sControlledCharacter_5C1B8C) &&
         !sControlledCharacter_5C1B8C->field_114_flags.Get(Flags_114::e114_Bit8_bInvisible))
     {
         GameSpeakResponse_4BF470();
@@ -6705,7 +6705,7 @@ void Slig::TurnOrWalk_4BD6A0(int a2)
         }
     }
 
-    WaitOrWalk_4BE870(); 
+    WaitOrWalk_4BE870();
 }
 
 void Slig::ToPanicRunning_4BCA30()
@@ -6753,7 +6753,7 @@ void Slig::RespondToEnemyOrPatrol_4B3140()
 
 __int16 CCSTD Slig::IsAbeEnteringDoor_4BB990(BaseAliveGameObject* pThis)
 {
-    if (((pThis->field_4_typeId == Types::eAbe_69) && 
+    if (((pThis->field_4_typeId == Types::eAbe_69) &&
         (pThis->field_106_current_motion == eAbeStates::State_114_DoorEnter_459470 && pThis->field_20_animation.field_92_current_frame > 7)) ||
         (pThis->field_106_current_motion == eAbeStates::State_115_DoorExit_459A40 && pThis->field_20_animation.field_92_current_frame < 4))
     {
@@ -6916,7 +6916,7 @@ __int16 Slig::FindSwitch_4B9A50()
 
 __int16 Slig::NearOrFacingActiveChar_4B9930(BaseAliveGameObject* pObj)
 {
-    if (pObj->vIsObjNearby_4253B0(ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromDouble(0.5), sControlledCharacter_5C1B8C) || 
+    if (pObj->vIsObjNearby_4253B0(ScaleToGridSize_4498B0(field_CC_sprite_scale) * FP_FromDouble(0.5), sControlledCharacter_5C1B8C) ||
         sControlledCharacter_5C1B8C->vIsFacingMe_4254A0(pObj))
     {
         return 1;
@@ -6976,7 +6976,7 @@ __int16 Slig::HeardGlukkonToListenTo_4B9690(GameSpeakEvents glukkonSpeak)
         FP_GetExponent(sControlledCharacter_5C1B8C->field_BC_ypos),
         FP_GetExponent(field_B8_xpos),
         FP_GetExponent(field_BC_ypos));
-    
+
     if (!NearOrFacingActiveChar_4B9930(this))
     {
         return 0;
@@ -6993,7 +6993,7 @@ __int16 Slig::HeardGlukkonToListenTo_4B9690(GameSpeakEvents glukkonSpeak)
         if (pObj != this && pObj->field_4_typeId == Types::eSlig_125)
         {
             auto* pOtherSlig = static_cast<Slig*>(pObj);
-            if (pOtherSlig->field_CC_sprite_scale == sControlledCharacter_5C1B8C->field_CC_sprite_scale && 
+            if (pOtherSlig->field_CC_sprite_scale == sControlledCharacter_5C1B8C->field_CC_sprite_scale &&
                 gMap_5C3030.Is_Point_In_Current_Camera_4810D0(
                     pOtherSlig->field_C2_lvl_number,
                     pOtherSlig->field_C0_path_number,
@@ -7300,10 +7300,10 @@ __int16 Slig::vTakeDamage_4B2470(BaseGameObject* pFrom)
 
 __int16 Slig::vIsFacingMe_4B23D0(BaseAnimatedWithPhysicsGameObject* pWho)
 {
-    if (field_106_current_motion != eSligMotions::M_TurnAroundStanding_5_4B6390 || 
+    if (field_106_current_motion != eSligMotions::M_TurnAroundStanding_5_4B6390 ||
         field_20_animation.field_92_current_frame < 6)
     {
-        if (pWho->field_B8_xpos <= field_B8_xpos && 
+        if (pWho->field_B8_xpos <= field_B8_xpos &&
             field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX))
         {
             return 1;

--- a/Source/AliveLibAE/Slog.cpp
+++ b/Source/AliveLibAE/Slog.cpp
@@ -130,16 +130,16 @@ Slog* Slog::ctor_4C4540(FP xpos, FP ypos, FP scale, __int16 bListenToSligs, __in
 
     field_BC_ypos = ypos;
     field_B8_xpos = xpos;
-    
+
     field_CC_sprite_scale = scale;
-    
+
     Init_4C46A0();
-    
+
     field_160_flags.Clear(Flags_160::eBit5_CommandedToAttack);
     field_12C_tlvInfo = 0xFFFF;
     field_120_brain_state_idx = 2;
     field_122_brain_state_result = 0;
-    
+
     BaseAliveGameObject* pTarget = FindTarget_4C33C0(0, 0);
     if (!pTarget)
     {
@@ -183,7 +183,7 @@ Slog* Slog::ctor_4C42E0(Path_Slog* pTlv, int tlvInfo)
     }
 
     field_C_objectId = tlvInfo;
-    
+
     Init_4C46A0();
 
     field_160_flags.Clear(Flags_160::eBit9_MovedOffScreen);
@@ -215,7 +215,7 @@ Slog* Slog::ctor_4C42E0(Path_Slog* pTlv, int tlvInfo)
     {
         field_106_current_motion = eSlogMotions::M_Idle_0_4C5F90;
     }
-    
+
     VUpdate();
 
     return this;
@@ -336,7 +336,7 @@ int CC Slog::CreateFromSaveState_4C54F0(const BYTE* pBuffer)
     BYTE** ppRes = pSlog->ResBlockForMotion_4C4A80(pState->field_28_current_motion);
 	const AnimRecord& animRec = AnimRec(sSlogFrameOffsetTable_5609D8[pSlog->field_106_current_motion]);
     pSlog->field_20_animation.Set_Animation_Data_409C80(animRec.mFrameTableOffset, ppRes);
-	
+
     pSlog->field_20_animation.field_92_current_frame = pState->field_2A_anim_cur_frame;
     pSlog->field_20_animation.field_E_frame_change_counter = pState->field_2C_frame_change_counter;
 
@@ -1266,7 +1266,7 @@ void Slog::M_Eating_20_4C75F0()
             pBlood->ctor_40F0B0(
                 ((field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX)) != 0 ? FP_FromInteger(-25) : FP_FromInteger(25)) * field_CC_sprite_scale + field_B8_xpos,
                 field_BC_ypos - (FP_FromInteger(4) * field_CC_sprite_scale),
-                FP_FromInteger(0), FP_FromInteger(0), 
+                FP_FromInteger(0), FP_FromInteger(0),
                 field_CC_sprite_scale, 12);
         }
     }
@@ -1363,19 +1363,19 @@ const __int16 sSlogResponseMotion_560930[3][10] =
         eSlogMotions::M_Run_2_4C6340,
         eSlogMotions::M_StopRunning_6_4C66C0,
         -2,
-        0, 0, 0, 0, 0, 0 
+        0, 0, 0, 0, 0, 0
     },
     {
         eSlogMotions::M_StartFastBarking_12_4C7880,
         -2,
-        0, 0, 0, 0, 0, 0, 0, 0 
+        0, 0, 0, 0, 0, 0, 0, 0
     }
 };
 
 __int16 Slog::AI_ListeningToSlig_0_4C3790()
 {
     auto pObj = static_cast<BaseAliveGameObject*>(sObjectIds_5C1B70.Find_449CF0(field_138_listening_to_slig_id));
-    
+
     // TODO: OG bug - return never used?
     //sObjectIds_5C1B70.Find_449CF0(field_118);
 
@@ -1538,7 +1538,7 @@ __int16 Slog::AI_ListeningToSlig_State_2_Listening(const FP xpos1GridAHead, Base
         {
             field_13C_waiting_counter++;
         }
-        // Fall through.
+        [[fallthrough]];
 
     case GameSpeakEvents::Slig_HereBoy_28:
         field_124_timer = sGnFrame_5C1B84 - Math_NextRandom() % 8 + 15;
@@ -1684,7 +1684,7 @@ __int16 Slog::AI_ListeningToSlig_State_0_Init()
 __int16 Slog::AI_Idle_1_4C2830()
 {
     BaseGameObject* pTarget = sObjectIds_5C1B70.Find_449CF0(field_118_target_id);
-    
+
     // OG dead code - return never used
     //sObjectIds_5C1B70.Find_449CF0(field_138);
 
@@ -2350,7 +2350,7 @@ __int16 Slog::AI_ChasingAbe_State_11_ChasingAfterBone()
                 gridSize = ScaleToGridSize_4498B0(field_CC_sprite_scale);
             }
 
-            // TODO: Same check twice ?? 
+            // TODO: Same check twice ??
             if (CollisionCheck_4C5480(field_CC_sprite_scale * FP_FromInteger(20), FP_FromInteger(4) * gridSize))
             {
                 FP gridSize2 = {};
@@ -2891,12 +2891,12 @@ void Slog::Init_4C46A0()
     }
 
     field_D6_scale = 1;
-    
+
     FP hitX = {};
     FP hitY = {};
     if (sCollisions_DArray_5C1128->Raycast_417A60(
-        field_B8_xpos, field_BC_ypos, 
-        field_B8_xpos, field_BC_ypos + FP_FromInteger(24), 
+        field_B8_xpos, field_BC_ypos,
+        field_B8_xpos, field_BC_ypos + FP_FromInteger(24),
         &field_100_pCollisionLine, &hitX, &hitY, 1) == 1)
     {
         field_BC_ypos = hitY;
@@ -2975,10 +2975,10 @@ void Slog::vUpdate_4C50D0()
         {
             DDCheat::DebugStr_4F5560("Slog:  Motion=%d  BrainState=%d\n", field_106_current_motion, field_122_brain_state_result);
         }
-        
+
         const FP oldXPos = field_B8_xpos;
         const FP oldYPos = field_BC_ypos;
-        
+
         (this->*sSlog_motion_table_560978[field_106_current_motion])();
 
         if (oldXPos != field_B8_xpos || oldYPos != field_BC_ypos)
@@ -3021,7 +3021,7 @@ void Slog::dtor_4C49A0()
     }
 
     MusicController::PlayMusic_47FD60(MusicController::MusicTypes::eNone_0, this, 0, 0);
-    
+
     if (!field_160_flags.Get(Flags_160::eBit3_Shot))
     {
         sSlogCount_BAF7F2--;
@@ -3129,7 +3129,7 @@ void Slog::ToJump_4C5C60()
 {
     field_C4_velx = (field_20_animation.field_4_flags.Get(AnimFlags::eBit5_FlipX) ? FP_FromDouble(-10.18) : FP_FromDouble(10.18)) * field_CC_sprite_scale;
     field_C8_vely = FP_FromInteger(-8) * field_CC_sprite_scale;
-    
+
     field_F8_LastLineYPos = field_BC_ypos;
 
     VOnTrapDoorOpen();
@@ -3331,7 +3331,7 @@ BaseAliveGameObject* Slog::FindTarget_4C33C0(__int16 bKillSligs, __int16 bLookin
             case Types::eAbe_69:
             case Types::eMudokon_110:
             case Types::eSlig_125:
-                if (bKillSligs || (!bKillSligs && 
+                if (bKillSligs || (!bKillSligs &&
                     (pObj->field_4_typeId == Types::eAbe_69 ||
                       pObj->field_4_typeId == Types::eCrawlingSlig_26 ||
                       pObj->field_4_typeId == Types::eFlyingSlig_54 ||

--- a/Source/AliveLibAE/Sound/PsxSpuApi.cpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.cpp
@@ -85,7 +85,7 @@ public:
     {
         return sGlobalVolumeLevel_left_BD1CDC;
     }
-    
+
     virtual VabUnknown& s512_byte() override
     {
         return s512_byte_C13180;
@@ -899,7 +899,7 @@ EXPORT signed int CC MIDI_ParseMidiMessage_4FD100(int idx)
                         {
                             tempoByte3 = MIDI_ReadByte_4FD6B0(pCtx) << 16;
                             tempoByte2 = MIDI_ReadByte_4FD6B0(pCtx) << 8;
-                            
+
                             // TODO: This is too short
                             fullTempo = tempoByte3 | tempoByte2 | MIDI_ReadByte_4FD6B0(pCtx);
                             MIDI_SetTempo_4FDB80(static_cast<short>(idx), 0, static_cast<short>(fullTempo));
@@ -1405,7 +1405,7 @@ EXPORT void CC MIDI_ADSR_Update_4FDCE0()
                     pChannel->field_1C_adsr.field_3_state = 2;
                     pChannel->field_14_time += pChannel->field_1C_adsr.field_4_attack;
                     timeDiff1 -= pChannel->field_1C_adsr.field_4_attack;
-                    // Fall through to case 3
+                    [[fallthrough]];
                 }
                 else
                 {
@@ -1429,7 +1429,7 @@ EXPORT void CC MIDI_ADSR_Update_4FDCE0()
                 timeDiff1 -= pChannel->field_1C_adsr.field_6_sustain;
                 if (MIDI_Set_Volume_4FDE80(pChannel, pChannel->field_C_vol * pChannel->field_1C_adsr.field_8_decay >> 4))
                 {
-                    // Fall through to case 4
+                    [[fallthrough]];
                 }
                 else
                 {
@@ -1443,7 +1443,7 @@ EXPORT void CC MIDI_ADSR_Update_4FDCE0()
                     timeDiff1 = 0;
                     timeDiffSquared = 0;
                     pChannel->field_C_vol = pChannel->field_8_left_vol;
-                    // Fall through to case 5
+                    [[fallthrough]];
                 }
                 else
                 {

--- a/Source/AliveLibAE/Sound/PsxSpuApi.cpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.cpp
@@ -1400,14 +1400,7 @@ EXPORT void CC MIDI_ADSR_Update_4FDCE0()
                 }
                 break;
             case 2:
-                if (timeDiff1 >= pChannel->field_1C_adsr.field_4_attack)
-                {
-                    pChannel->field_1C_adsr.field_3_state = 2;
-                    pChannel->field_14_time += pChannel->field_1C_adsr.field_4_attack;
-                    timeDiff1 -= pChannel->field_1C_adsr.field_4_attack;
-                    [[fallthrough]];
-                }
-                else
+                if (timeDiff1 < pChannel->field_1C_adsr.field_4_attack)
                 {
                     MIDI_Set_Volume_4FDE80(
                         pChannel,
@@ -1417,6 +1410,11 @@ EXPORT void CC MIDI_ADSR_Update_4FDCE0()
                             * (double)pChannel->field_C_vol));
                     break;
                 }
+
+                pChannel->field_1C_adsr.field_3_state = 2;
+                pChannel->field_14_time += pChannel->field_1C_adsr.field_4_attack;
+                timeDiff1 -= pChannel->field_1C_adsr.field_4_attack;
+                [[fallthrough]];
             case 3:
                 if (timeDiff1 < pChannel->field_1C_adsr.field_6_sustain)
                 {
@@ -1427,14 +1425,11 @@ EXPORT void CC MIDI_ADSR_Update_4FDCE0()
                 pChannel->field_1C_adsr.field_3_state = 3;
                 pChannel->field_14_time += pChannel->field_1C_adsr.field_6_sustain;
                 timeDiff1 -= pChannel->field_1C_adsr.field_6_sustain;
-                if (MIDI_Set_Volume_4FDE80(pChannel, pChannel->field_C_vol * pChannel->field_1C_adsr.field_8_decay >> 4))
-                {
-                    [[fallthrough]];
-                }
-                else
+                if (!(MIDI_Set_Volume_4FDE80(pChannel, pChannel->field_C_vol * pChannel->field_1C_adsr.field_8_decay >> 4)))
                 {
                     break;
                 }
+                [[fallthrough]];
             case 4:
                 if (timeDiff1 > 15000)
                 {

--- a/Source/AliveLibAO/Abe.cpp
+++ b/Source/AliveLibAO/Abe.cpp
@@ -732,7 +732,7 @@ Abe* Abe::ctor_420770(int frameTableOffset, int /*r*/, int /*g*/, int /*b*/)
     field_6_flags.Set(Options::eSurviveDeathReset_Bit9);
 
     Init_GameStates_41CEC0();
-    
+
     // Zero out the resource array
     field_1A4_resources = {};
 
@@ -794,7 +794,7 @@ Abe* Abe::ctor_420770(int frameTableOffset, int /*r*/, int /*g*/, int /*b*/)
     ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kDeathFlareResID, 1, 0);
     ResourceManager::LoadResourceFile_455270("DOVBASIC.BAN", nullptr);
     ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kDovbasicResID, 1, 0);
-    
+
     field_128_resource_idx = 45;
     Animation_Init_417FD0(frameTableOffset, 135, 80, field_1A4_resources.res[45], 1);
 
@@ -880,7 +880,7 @@ Abe* Abe::ctor_420770(int frameTableOffset, int /*r*/, int /*g*/, int /*b*/)
 BaseGameObject* Abe::dtor_420C80()
 {
     SetVTable(this, 0x4BB158);
-    
+
     SND_Seq_Stop_477A60(SeqId::eMudokonChant1_11);
 
     BYTE** ppRes = nullptr;
@@ -989,7 +989,7 @@ BaseGameObject* Abe::dtor_420C80()
     }
 
     sActiveHero_507678 = nullptr;
-    
+
     // OG fix for going back to menu with DDCheat on and then it crashes reading a deleted pointer
     // ditto for the ending where MeatSaw/Invisible switch screen change/update funcs read it.
     sControlledCharacter_50767C = nullptr;
@@ -1018,7 +1018,7 @@ void Abe::vUpdate_41FDB0()
         {
             field_100_health = FP_FromInteger(1);
         }
-        
+
         if (!Input_IsChanting_4334C0())
         {
             field_2A8_flags.Clear(Flags_2A8::e2A8_Bit7);
@@ -1144,7 +1144,7 @@ void Abe::vUpdate_41FDB0()
                         field_10_anim.Set_Animation_Data_402A40(
                             sAbeFrameOffsetTable_4C61A0[field_FC_current_motion],
                             StateToAnimResource_4204F0(field_FC_current_motion));
-                        
+
                         field_12C_timer = gnFrameCount_507670;
 
                         if (state_idx == eAbeStates::State_15_Null_42A210 ||
@@ -1357,7 +1357,7 @@ void Abe::FreeElumRes_420F80()
     {
         // Empty
     }
- 
+
     field_1A4_resources.res[58] = nullptr;
     ResourceManager::FreeResource_455550(field_1A4_resources.res[46]);
 
@@ -1510,8 +1510,8 @@ __int16 Abe::RunTryEnterWell_425880()
         TlvTypes::WellLocal_11));
     if (pWellLocal)
     {
-        if (pWellLocal->field_18_scale == 0 && field_BC_sprite_scale == FP_FromInteger(1) ||
-            pWellLocal->field_18_scale == 1 && field_BC_sprite_scale == FP_FromDouble(0.5))
+        if ((pWellLocal->field_18_scale == 0 && field_BC_sprite_scale == FP_FromInteger(1)) ||
+            (pWellLocal->field_18_scale == 1 && field_BC_sprite_scale == FP_FromDouble(0.5)))
         {
             field_2A8_flags.Clear(Flags_2A8::e2A8_Bit4_snap_abe);
             field_F0_pTlv = pWellLocal;
@@ -1528,8 +1528,8 @@ __int16 Abe::RunTryEnterWell_425880()
         TlvTypes::WellExpress_45));
     if (pWellExpress)
     {
-        if (pWellExpress->field_18_scale == 0 && field_BC_sprite_scale == FP_FromInteger(1) ||
-            pWellExpress->field_18_scale == 1 && field_BC_sprite_scale == FP_FromDouble(0.5))
+        if ((pWellExpress->field_18_scale == 0 && field_BC_sprite_scale == FP_FromInteger(1)) ||
+            (pWellExpress->field_18_scale == 1 && field_BC_sprite_scale == FP_FromDouble(0.5)))
         {
             field_2A8_flags.Clear(Flags_2A8::e2A8_Bit4_snap_abe);
             field_F0_pTlv = pWellExpress;
@@ -1567,8 +1567,8 @@ BaseAliveGameObject* CC Abe::FindObjectToPossess_421410()
             if (pObj->field_10A_flags.Get(Flags_10A::e10A_Bit1_Can_Be_Possessed))
             {
                 if (pObj->field_4_typeId != Types::eSlig_88 ||
-                    pObj->Is_In_Current_Camera_417CC0() == CameraPos::eCamCurrent_0 &&
-                    pObj->field_100_health > FP_FromInteger(0))
+                    (pObj->Is_In_Current_Camera_417CC0() == CameraPos::eCamCurrent_0 &&
+                    pObj->field_100_health > FP_FromInteger(0)))
                 {
                     return pObj;
                 }
@@ -1859,7 +1859,7 @@ void Abe::MoveForward_422FC0()
                 field_F8_pLiftPoint->VRemove(this);
                 field_F8_pLiftPoint->field_C_refCount--;
                 field_F8_pLiftPoint = nullptr;
-                
+
             }
         }
         else if (field_F4_pLine->field_8_type == 32 || field_F4_pLine->field_8_type == 36)
@@ -1934,7 +1934,7 @@ void Abe::ElumFree_4228F0()
         ResourceManager::FreeResource_455550(ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kElumUnknownResID_110, 1, 0));
         ResourceManager::FreeResource_455550(ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kElumUnknownResID_223, 1, 0));
         ResourceManager::FreeResource_455550(ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kElmprmntResID__222, 0, 0));
-        
+
         if (gElum_507680->field_FC_current_motion != eElumStates::State_1_Idle_412990)
         {
             gElum_507680->Vsub_416120();
@@ -2461,8 +2461,8 @@ __int16 Abe::ToLeftRightMovement_422AA0()
     const FP gridSize = ScaleToGridSize_41FA30(field_BC_sprite_scale);
     const BOOL flipX = field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX);
 
-    if (flipX && Input().IsAnyPressed(sInputKey_Right_4C6590) ||
-        !flipX && Input().IsAnyPressed(sInputKey_Left_4C6594))
+    if ((flipX && Input().IsAnyPressed(sInputKey_Right_4C6590)) ||
+        (!flipX && Input().IsAnyPressed(sInputKey_Left_4C6594)))
     {
         field_FC_current_motion = eAbeStates::State_2_StandingTurn_426040;
         return 1;
@@ -3010,7 +3010,7 @@ __int16 Abe::MoveLiftUpOrDown_42F190(FP yVelocity)
 
 void Abe::vScreenChanged_422640()
 {
-    if (sControlledCharacter_50767C == this || 
+    if (sControlledCharacter_50767C == this ||
         sControlledCharacter_50767C == gElum_507680)
     {
         field_B2_lvl_number = gMap_507BA8.field_A_level;
@@ -4169,10 +4169,10 @@ void Abe::State_0_Idle_423520()
 void Abe::State_1_WalkLoop_423F90()
 {
     field_10C_prev_held |= Input().Pressed();
-    
+
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     MoveForward_422FC0();
 
     if (field_FC_current_motion == eAbeStates::State_1_WalkLoop_423F90)
@@ -4181,8 +4181,8 @@ void Abe::State_1_WalkLoop_423F90()
         {
         case 2:
         {
-            if (field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594) ||
-                field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590))
+            if ((field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594)) ||
+                (field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590)))
             {
                 field_FC_current_motion = eAbeStates::State_5_MidWalkToIdle_424490;
                 field_10C_prev_held = 0;
@@ -4286,7 +4286,7 @@ void Abe::State_1_WalkLoop_423F90()
                 field_2A8_flags.Set(Flags_2A8::e2A8_Bit3_WalkToRun);
                 MapFollowMe_401D30(1);
             }
-            
+
             if (Input().IsAnyPressed(sInputKey_Run_4C65A8))
             {
                 field_FC_current_motion = eAbeStates::State_50_WalkToRun_424560;
@@ -4310,7 +4310,7 @@ void Abe::State_2_StandingTurn_426040()
 
     if (field_10_anim.field_92_current_frame == 4)
     {
-        if (Input().IsAnyPressed(sInputKey_Run_4C65A8) && 
+        if (Input().IsAnyPressed(sInputKey_Run_4C65A8) &&
             Input().IsAnyPressed(sInputKey_Right_4C6590 | sInputKey_Left_4C6594))
         {
             field_FC_current_motion = eAbeStates::State_63_TurnToRun_42A0A0;
@@ -4339,7 +4339,7 @@ void Abe::State_2_StandingTurn_426040()
 
         if (field_FE_next_state)
         {
-            // OG bug: this local variable allows you to "store" your next state if you face the opposite 
+            // OG bug: this local variable allows you to "store" your next state if you face the opposite
             // ledge direction and press down/up and then interrupt it by running away before you hoist.
             const short kNext_state = field_FE_next_state;
             if (field_FE_next_state != eAbeStates::State_139_ElumMountBegin_42E090)
@@ -4607,7 +4607,7 @@ void Abe::State_4_WalkToIdle_4243C0()
 {
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     MoveForward_422FC0();
 
     if (field_10_anim.field_92_current_frame != 0)
@@ -4651,7 +4651,7 @@ void Abe::State_5_MidWalkToIdle_424490()
 {
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     MoveForward_422FC0();
 
     if (field_10_anim.field_92_current_frame)
@@ -5158,7 +5158,7 @@ void Abe::State_23_CrouchSpeak_428A90()
     if (field_10_anim.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame))
     {
         field_FC_current_motion = eAbeStates::State_19_CrouchIdle_4284C0;
-        
+
         CrouchingGameSpeak_427F90();
 
         if (field_FC_current_motion == eAbeStates::State_22_CrouchSpeak_428A30 || field_FC_current_motion == eAbeStates::State_23_CrouchSpeak_428A90)
@@ -5261,8 +5261,8 @@ void Abe::State_25_RollLoop_427BB0()
             {
                 MapFollowMe_401D30(TRUE);
 
-                if (field_B4_velx > FP_FromInteger(0) && !Input().IsAnyPressed(sInputKey_Right_4C6590) ||
-                    field_B4_velx < FP_FromInteger(0) && !Input().IsAnyPressed(sInputKey_Left_4C6594))
+                if ((field_B4_velx > FP_FromInteger(0) && !Input().IsAnyPressed(sInputKey_Right_4C6590)) ||
+                    (field_B4_velx < FP_FromInteger(0) && !Input().IsAnyPressed(sInputKey_Left_4C6594)))
                 {
                     field_FC_current_motion = eAbeStates::State_19_CrouchIdle_4284C0;
                     field_B4_velx = FP_FromInteger(0);
@@ -5333,8 +5333,8 @@ void Abe::State_27_RunSlideStop_425B60()
                     }
                 }
             }
-            else if (field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Right_4C6590) ||
-                    !field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Left_4C6594))
+            else if ((field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Right_4C6590)) ||
+                    (!field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Left_4C6594)))
             {
                 field_2A8_flags.Set(Flags_2A8::e2A8_Bit2);
                 field_E4_previous_motion = eAbeStates::State_28_RunTurn_425CE0;
@@ -6081,8 +6081,8 @@ void Abe::State_35_RunLoop_425060()
         }
 
         // Check turning in middle of run (pressing reverse direction of movement)
-        if (field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594) ||
-            field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590))
+        if ((field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594)) ||
+            (field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590)))
         {
             field_FC_current_motion = eAbeStates::State_28_RunTurn_425CE0;
             Environment_SFX_42A220(EnvironmentSfx::eRunSlide_4, 0, 0x7FFF, this);
@@ -6310,8 +6310,8 @@ void Abe::State_42_SneakLoop_424BB0()
             }
 
             if (WallHit_401930(field_BC_sprite_scale * FP_FromInteger(50), directedScale) ||
-                field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594) ||
-                field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590) ||
+                (field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594)) ||
+                (field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590)) ||
                 !Input().IsAnyPressed(sInputKey_Right_4C6590 | sInputKey_Left_4C6594))
             {
                 field_FC_current_motion = eAbeStates::State_48_SneakToIdle_424F80;
@@ -6367,9 +6367,9 @@ void Abe::State_42_SneakLoop_424BB0()
             directedScale = ScaleToGridSize_41FA30(field_BC_sprite_scale);
         }
 
-        if (WallHit_401930(field_BC_sprite_scale * FP_FromInteger(50), directedScale) || 
-            field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594) ||
-            field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590) ||
+        if (WallHit_401930(field_BC_sprite_scale * FP_FromInteger(50), directedScale) ||
+            (field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594)) ||
+            (field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590)) ||
             !Input().IsAnyPressed(sInputKey_Right_4C6590 | sInputKey_Left_4C6594))
         {
             field_FC_current_motion = eAbeStates::State_49_MidSneakToIdle_424FF0;
@@ -6380,7 +6380,7 @@ void Abe::State_42_SneakLoop_424BB0()
 void Abe::State_43_WalkToSneak_424790()
 {
     field_10C_prev_held |= Input().Pressed();
-    
+
     if (field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX))
     {
         field_B4_velx = -(ScaleToGridSize_41FA30(field_BC_sprite_scale) / FP_FromInteger(10));
@@ -6409,7 +6409,7 @@ void Abe::State_43_WalkToSneak_424790()
 void Abe::State_44_SneakToWalk_4249A0()
 {
     field_10C_prev_held |= Input().Pressed();
-    
+
     if (field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX))
     {
         field_B4_velx = -(ScaleToGridSize_41FA30(field_BC_sprite_scale) / FP_FromInteger(9));
@@ -6525,7 +6525,7 @@ void Abe::State_48_SneakToIdle_424F80()
     }
 
     MoveForward_422FC0();
-    
+
     if (field_10_anim.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame))
     {
         MapFollowMe_401D30(1);
@@ -6553,7 +6553,7 @@ void Abe::State_49_MidSneakToIdle_424FF0()
 void Abe::State_50_WalkToRun_424560()
 {
     field_10C_prev_held |= Input().Pressed();
-    
+
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
 
@@ -6620,7 +6620,7 @@ void Abe::State_51_MidWalkToRun_424670()
 void Abe::State_52_RunToWalk_4255E0()
 {
     field_10C_prev_held |= Input().Pressed();
-    
+
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
 
@@ -6707,7 +6707,7 @@ void Abe::State_54_RunTurnToRun_425EA0()
 void Abe::State_55_RunTurnToWalk_425F70()
 {
     field_10C_prev_held |= Input().Pressed();
-    
+
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
 
@@ -6813,7 +6813,7 @@ void Abe::State_59_DeathDropFall_42CBE0()
         else if (static_cast<int>(gnFrameCount_507670) == field_118_timer - 24)
         {
             Environment_SFX_42A220(EnvironmentSfx::eFallingDeathScreamHitGround_15, 0, 0x7FFF, this);
-            
+
             auto pScreenShake = ao_new<ScreenShake>();
             if (pScreenShake)
             {
@@ -7499,7 +7499,7 @@ void Abe::State_66_LedgeHang_428D90()
 void Abe::State_67_ToOffScreenHoist_428C50()
 {
     field_AC_ypos -= (field_BC_sprite_scale * FP_FromInteger(80));
-    
+
     field_D0_pShadow->field_14_flags.Toggle(Shadow::eBit1_ShadowAtBottom);
 
     PathLine* pLine = nullptr;
@@ -7569,7 +7569,7 @@ void Abe::State_68_LedgeHangWobble_428E50()
 
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     FollowLift_42EE90();
 
     if (Input().IsAnyPressed(sInputKey_Up_4C6598))
@@ -7963,9 +7963,9 @@ void Abe::State_79_WellShotOut_431730()
     }
 
     if (field_10_anim.field_4_flags.Get(AnimFlags::eBit12_ForwardLoopCompleted)
-        || field_FC_current_motion != eAbeStates::State_79_WellShotOut_431730
+        || (field_FC_current_motion != eAbeStates::State_79_WellShotOut_431730
         && field_FC_current_motion != eAbeStates::State_85_431710
-        && field_FC_current_motion != eAbeStates::State_76_ToWellShotOut_431720)
+        && field_FC_current_motion != eAbeStates::State_76_ToWellShotOut_431720))
     {
         if (field_BC_sprite_scale == FP_FromDouble(0.5))
         {
@@ -8032,7 +8032,7 @@ void Abe::State_81_InsideWellExpress_431320()
         field_194_camera = pExpressWell->field_28_off_camera;
         field_196_door_id = pExpressWell->field_2A_off_well_id;
     }
-    
+
     field_120_x_vel_slow_by = FP_FromInteger(0);
 
     if (gMap_507BA8.field_0_current_level == LevelIds::eLines_2)
@@ -8562,7 +8562,7 @@ void Abe::State_91_FallingFromGrab_429780()
     {
         field_FC_current_motion = eAbeStates::State_87_428FA0;
     }
-    
+
     State_3_Fall_42E7F0();
 
     if (field_FC_current_motion == eAbeStates::State_86_FallLandDie_42EDD0)
@@ -9080,7 +9080,7 @@ void Abe::State_135_LiftGrabIdle_42F000()
 
     auto pLiftPoint = static_cast<LiftPoint*>(field_F8_pLiftPoint);
     pLiftPoint->Move_435740(FP_FromInteger(0), FP_FromInteger(0), 0);
-    
+
     field_B8_vely = FP_FromInteger(0);
 
     if (gBeeInstanceCount_5076B0 > 0 && gBeesNearAbe_5076AC)
@@ -9243,7 +9243,7 @@ void Abe::State_138_ElumUnmountEnd_42E390()
         field_1A4_resources.res[10] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kAbefallResID, 1, 0);
         field_1A4_resources.res[38] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kAbeommResID, 1, 0);
         field_1A4_resources.res[9] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kAbesmashResID, 1, 0);
-        
+
         field_F4_pLine = gElum_507680->field_F4_pLine;
 
         if (field_F8_pLiftPoint)
@@ -9482,7 +9482,7 @@ void Abe::State_148_Shot_4296A0()
 
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     State_3_Fall_42E7F0();
 
     if (field_FC_current_motion != eAbeStates::State_148_Shot_4296A0 && !gAbeInvulnerableCheat_5076E4)

--- a/Source/AliveLibAO/Abe.hpp
+++ b/Source/AliveLibAO/Abe.hpp
@@ -417,7 +417,7 @@ ALIVE_ASSERT_SIZEOF(Path_Stone, 0x2C);
 
 class Abe : public BaseAliveGameObject
 {
-public: 
+public:
     BOOL Is_Celling_Above();
 
     EXPORT Abe* ctor_420770(int frameTableOffset, int a3, int a4, int a5);
@@ -763,4 +763,4 @@ EXPORT int CC Mudokon_SFX_42A4D0(MudSounds idx, int volume, int pitch, BaseAlive
 
 EXPORT int CC XGrid_Index_To_XPos_41FA60(FP scale, int xGridIndex);
 
-};
+}

--- a/Source/AliveLibAO/AbilityRing.cpp
+++ b/Source/AliveLibAO/AbilityRing.cpp
@@ -65,7 +65,7 @@ AbilityRing* AbilityRing::ctor_455860(FP xpos, FP ypos, __int16 type)
         field_23C_xpos = xpos;
         field_240_ypos = ypos;
 
- 
+
         field_25E_screenX = FP_GetExponent(pScreenManager_4FF7C8->field_10_pCamPos->field_0_x - FP_FromInteger(pScreenManager_4FF7C8->field_14_xpos));
         field_260_screenY = FP_GetExponent(pScreenManager_4FF7C8->field_10_pCamPos->field_4_y - FP_FromInteger(pScreenManager_4FF7C8->field_16_ypos));
 
@@ -93,7 +93,7 @@ AbilityRing* AbilityRing::ctor_455860(FP xpos, FP ypos, __int16 type)
             {
                 r = {};
             }
-            // Fall through
+            [[fallthrough]];
 
         case 2:
             field_258_ring_thickness = FP_FromInteger(8);
@@ -120,7 +120,7 @@ AbilityRing* AbilityRing::ctor_455860(FP xpos, FP ypos, __int16 type)
         case 4:
             field_278_pTarget_obj = sActiveHero_507678;
             field_278_pTarget_obj->field_C_refCount++;
-            // Fall through
+            [[fallthrough]];
 
         case 5:
         case 6:
@@ -330,7 +330,7 @@ void AbilityRing::VUpdate_455ED0()
 
     case 1:
         CollideWithObjects_456250();
-        // Fall through
+        [[fallthrough]];
 
     case 2:
         field_248_right += field_24C_speed;

--- a/Source/AliveLibAO/BeeSwarm.cpp
+++ b/Source/AliveLibAO/BeeSwarm.cpp
@@ -158,8 +158,8 @@ void BeeSwarm::VScreenChange_480D40()
         }
     }
 
-    if (!sActiveHero_507678 || field_D98_pChaseTarget == sActiveHero_507678
-        && sActiveHero_507678->field_FC_current_motion == eAbeStates::State_156_DoorEnter_42D370)
+    if (!sActiveHero_507678 || (field_D98_pChaseTarget == sActiveHero_507678
+        && sActiveHero_507678->field_FC_current_motion == eAbeStates::State_156_DoorEnter_42D370))
     {
         field_6_flags.Set(Options::eDead_Bit3);
     }
@@ -588,7 +588,7 @@ void BeeSwarm::VUpdate_47FF50()
     field_A8_xpos = field_E4_bees.bees[0].field_0_xpos;
     field_AC_ypos = field_E4_bees.bees[0].field_4_ypos;
 }
- 
+
 void BeeSwarm::ToFlyAwayAndDie()
 {
     field_D9C_alive_timer = gnFrameCount_507670 + 120;

--- a/Source/AliveLibAO/BirdPortal.cpp
+++ b/Source/AliveLibAO/BirdPortal.cpp
@@ -385,7 +385,7 @@ void BirdPortal::VUpdate_4523D0()
         auto pTarget = Abe::FindObjectToPossess_421410();
         if (!Event_Get_417250(8) || pTarget)
         {
-            if (IsScaredAway_4532E0() || Event_Get_417250(2) || Event_Get_417250(8) && pTarget)
+            if (IsScaredAway_4532E0() || Event_Get_417250(2) || (Event_Get_417250(8) && pTarget))
             {
                 for (int i = 0; i < field_4C_pDovesArray->Size(); i++)
                 {
@@ -527,7 +527,7 @@ void BirdPortal::VUpdate_4523D0()
 
     case States::State_6:
         Event_Broadcast_417220(kEvent_18, this);
-        if (field_10_portal_type != PortalType::eWorker_1 && field_10_portal_type != PortalType::eShrykull_2 || Event_Get_417250(8))
+        if ((field_10_portal_type != PortalType::eWorker_1 && field_10_portal_type != PortalType::eShrykull_2) || Event_Get_417250(8))
         {
             if ((Math_NextRandom() % 8) == 0)
             {
@@ -748,7 +748,7 @@ void BirdPortal::VUpdate_4523D0()
 
     case States::State_17:
     {
-        pScreenManager_4FF7C8->field_36_flags = pScreenManager_4FF7C8->field_36_flags & ~1 ^ 1;
+        pScreenManager_4FF7C8->field_36_flags = (pScreenManager_4FF7C8->field_36_flags & ~1) ^ 1;
         pScreenManager_4FF7C8->InvalidateRect_406E40(
             0,
             0,
@@ -947,10 +947,10 @@ void BirdPortal::VScreenChanged()
 void BirdPortal::VScreenChanged_4538E0()
 {
     if (field_14_state <= States::State_1 || field_14_state >= States::State_21 ||
-        (gMap_507BA8.field_0_current_level != gMap_507BA8.field_A_level || gMap_507BA8.field_2_current_path != gMap_507BA8.field_C_path) &&
+        ((gMap_507BA8.field_0_current_level != gMap_507BA8.field_A_level || gMap_507BA8.field_2_current_path != gMap_507BA8.field_C_path) &&
         (field_14_state != States::State_16 || field_10_portal_type != PortalType::eAbe_0 ||
             gMap_507BA8.field_A_level != field_50_dest_level ||
-            gMap_507BA8.field_C_path != field_52_dest_path))
+            gMap_507BA8.field_C_path != field_52_dest_path)))
     {
         field_6_flags.Set(Options::eDead_Bit3);
     }
@@ -1031,7 +1031,7 @@ void BirdPortal::VExitPortal_453720()
 {
     field_66_path = gMap_507BA8.field_2_current_path;
     field_64_level = gMap_507BA8.field_0_current_level;
-    
+
     auto pPortalExitTlv = static_cast<Path_BirdPortalExit*>(gMap_507BA8.TLV_First_Of_Type_In_Camera_4464A0(TlvTypes::BirdPortalExit_53, 0));
 
     PathLine* pLine = nullptr;

--- a/Source/AliveLibAO/Bullet.cpp
+++ b/Source/AliveLibAO/Bullet.cpp
@@ -292,15 +292,15 @@ BaseAliveGameObject* Bullet::ShootObject_409400(PSX_RECT* pRect)
         {
             if (pObjIter->field_10_anim.field_4_flags.Get(AnimFlags::eBit3_Render))
             {
-                if (field_10_type == BulletType::ePossessedSlig_0
+                if ((field_10_type == BulletType::ePossessedSlig_0
                     && (pObjIter->field_4_typeId == Types::eSlig_88
                     || pObjIter->field_4_typeId == Types::eMudokon_75
                     || pObjIter->field_4_typeId == Types::eAbe_43
-                    || pObjIter->field_4_typeId == Types::eSlog_89)
+                    || pObjIter->field_4_typeId == Types::eSlog_89))
 
                     || pObjIter->field_4_typeId == Types::eMudokon_75
                     || pObjIter->field_4_typeId == Types::eAbe_43
-                    || pObjIter->field_4_typeId == Types::eSlig_88 && sControlledCharacter_50767C == pObjIter)
+                    || (pObjIter->field_4_typeId == Types::eSlig_88 && sControlledCharacter_50767C == pObjIter))
                 {
                     PSX_RECT bRect = {};
                     pObjIter->VGetBoundingRect(&bRect, 1);

--- a/Source/AliveLibAO/ChimeLock.cpp
+++ b/Source/AliveLibAO/ChimeLock.cpp
@@ -105,7 +105,7 @@ ChimeLock* ChimeLock::ctor_40AB20(Path_ChimeLock* pTlv, signed int tlvInfo)
 
     field_140_targetY = FP_FromInteger(pTlv->field_10_top_left.field_2_y + 40);
     field_AC_ypos = FP_FromInteger(pTlv->field_10_top_left.field_2_y + 40);
-   
+
     field_B8_vely = FP_FromInteger(0);
 
     field_13C_targetX = FP_FromInteger(pTlv->field_10_top_left.field_0_x);
@@ -235,7 +235,7 @@ __int16 ChimeLock::DoNote_40BB20(__int16 note)
         return 0;
     }
 
-    if (!field_130_song_matching && !sVoiceCheat_507708 || (field_124_code1 / dword_4C5054[field_120_max_idx]) != note)
+    if ((!field_130_song_matching && !sVoiceCheat_507708) || (field_124_code1 / dword_4C5054[field_120_max_idx]) != note)
     {
         field_128_idx = 0;
         return 0;
@@ -508,7 +508,7 @@ void ChimeLock::VUpdate_40AEF0()
                 field_136_unpossession_timer = 30;
                 field_110_state = ChimeLockStates::eUnPossessing_3;
                 field_134_pressed = Input().Pressed();
-                
+
                 field_164_ChimeLock_num[0] = BellPositions::eNone_0;
                 field_164_ChimeLock_num[1] = BellPositions::eNone_0;
 

--- a/Source/AliveLibAO/DeathFadeOut.cpp
+++ b/Source/AliveLibAO/DeathFadeOut.cpp
@@ -13,7 +13,7 @@ void DeathFadeOut::VRender_419ED0(PrimHeader** ppOt)
 
     EffectBase::VRender_461690(ppOt);
 
-    if (field_68_current_fade_rgb == 255 && field_6C_direction || field_68_current_fade_rgb == 0 && !field_6C_direction)
+    if ((field_68_current_fade_rgb == 255 && field_6C_direction) || (field_68_current_fade_rgb == 0 && !field_6C_direction))
     {
         field_6E_bDone = 1;
         if (field_70_destroy_on_done)

--- a/Source/AliveLibAO/Electrocute.cpp
+++ b/Source/AliveLibAO/Electrocute.cpp
@@ -28,7 +28,7 @@ public:
         field_14_pal_colours_count = palDepth;
 
         field_6_flags.Set(Options::eDrawable_Bit4);
-        
+
         for (auto& palBufferEntry : field_A8_palBuffer)
         {
             palBufferEntry = colour;
@@ -209,7 +209,7 @@ void Electrocute::VScreenChanged_48D8B0()
 {
     // If the map has changed or target we are tracking has died then..
     if (gMap_507BA8.field_28_cd_or_overlay_num != gMap_507BA8.GetOverlayId_4440B0()
-        || field_10_obj_target && field_10_obj_target->field_6_flags.Get(BaseGameObject::eDead_Bit3))
+        || (field_10_obj_target && field_10_obj_target->field_6_flags.Get(BaseGameObject::eDead_Bit3)))
     {
         Stop_48D510();
     }
@@ -282,7 +282,7 @@ void Electrocute::VUpdate_48D5C0()
                 field_10_obj_target->field_10_anim.field_8C_pal_vram_xy,
                 field_10_obj_target->field_10_anim.field_90_pal_depth,
                 static_cast<short>(Pal_Make_Colour_447950(255u, 255, 255, 1)));
- 
+
         field_18_pPalOverwriters[1] = ao_new<PalleteOverwriter>();
         if (field_18_pPalOverwriters[1])
         {

--- a/Source/AliveLibAO/Elum.cpp
+++ b/Source/AliveLibAO/Elum.cpp
@@ -482,7 +482,7 @@ BYTE** Elum::GetResBlock_410D00(short currentMotion)
                 0);
         }
     }
-    
+
     field_126_res_idx = new_idx;
 
     return field_174_resources.res[new_idx];
@@ -658,7 +658,7 @@ void Elum::SetAbeAsPlayer_412520(__int16 abeMotion)
         sControlledCharacter_50767C = sActiveHero_507678;
         sActiveHero_507678->field_FE_next_state = abeMotion;
     }
-    
+
     // re-load some elum resources
     field_104_pending_resource_count += 2;
 
@@ -1948,10 +1948,10 @@ void Elum::State_2_Unknown_412C30()
 void Elum::State_3_WalkLoop_412C90()
 {
     field_10E_pressed |= Input().Pressed();
-    
+
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     MoveOnLine_412580(0);
 
     if (field_FC_current_motion == eElumStates::State_3_WalkLoop_412C90)
@@ -2138,7 +2138,7 @@ void Elum::State_5_WalkToIdle_4132D0()
 {
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     MoveOnLine_412580(0);
 
     if (field_10_anim.field_92_current_frame == 0)
@@ -2186,7 +2186,7 @@ void Elum::State_6_MidWalkToIdle_4133F0()
 {
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     MoveOnLine_412580(0);
 
     if (field_10_anim.field_92_current_frame == 0)
@@ -2834,7 +2834,7 @@ void Elum::RunJumpMidAndHopMid(MidType midType)
                     field_FC_current_motion = eElumStates::State_35_RunJumpLand_415580;
                     MapFollowMe_401D30(TRUE);
                     break;
-                    
+
                 case MidType::eHopMid:
                     field_B8_vely = FP_FromInteger(0);
                     field_B4_velx = FP_FromInteger(0);
@@ -2878,13 +2878,13 @@ void Elum::State_32_HopLand_415140()
         PSX_RECT bRect = {};
         VGetBoundingRect(&bRect, 1);
 
-        VOnCollisionWith( 
+        VOnCollisionWith(
             { bRect.x, static_cast<short>(bRect.y + 5) },
             { bRect.w, static_cast<short>(bRect.h + 5) },
-            ObjListPlatforms_50766C, 
-            1, 
+            ObjListPlatforms_50766C,
+            1,
             (TCollisionCallBack)&BaseAliveGameObject::OnTrapDoorIntersection_401C10);
-            
+
         MapFollowMe_401D30(TRUE);
 
         if (!ToNextState_4120F0())
@@ -3029,7 +3029,7 @@ void Elum::State_36_RunLoop_413720()
             field_10C_bFootStep2 = 0;
             return;
         }
-        
+
         Elum_SFX_416E10(ElumSounds::eRunningFootstep_1, 0);
 
         if (!field_10C_bFootStep2)
@@ -3138,8 +3138,8 @@ void Elum::State_37_RunSlideStop_4142E0()
 
     if (sControlledCharacter_50767C == this && field_10_anim.field_92_current_frame < 7)
     {
-        if (field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Right_4C6590) ||
-            !field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Left_4C6594))
+        if ((field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Right_4C6590)) ||
+            (!field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Left_4C6594)))
         {
             field_E4_previous_motion = eElumStates::State_12_RunTurn_414520;
             field_E6_last_anim_frame = field_10_anim.field_92_current_frame;
@@ -3167,7 +3167,7 @@ void Elum::State_38_RunTurnToRun_414810()
 {
     Event_Broadcast_417220(kEventNoise_0, this);
     Event_Broadcast_417220(kEventSuspiciousNoise_10, this);
-    
+
     MoveOnLine_412580(0);
 
     if (field_10_anim.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame))
@@ -3465,7 +3465,7 @@ void Elum::State_48_AbeMoutingBegin_415C40()
     if (sActiveHero_507678->field_FC_current_motion == eAbeStates::State_136_ElumMountEnd_42E110)
     {
         VFreeUnmountedResources_4112B0();
-        
+
         field_104_pending_resource_count += 2;
 
         ResourceManager::LoadResourceFile(
@@ -3487,7 +3487,7 @@ void Elum::State_49_AbeUnmountingBegin_415D00()
     if (sActiveHero_507678->field_FC_current_motion != eAbeStates::State_137_ElumUnmountBegin_42E2B0)
     {
         VFreeMountedResources_411200();
-        
+
         field_104_pending_resource_count += 2;
 
         ResourceManager::LoadResourceFile(
@@ -3629,7 +3629,7 @@ void Elum::VUpdate_4102A0()
             field_B4_velx = FP_FromInteger(0);
             field_B8_vely = FP_FromInteger(0);
         }
-        
+
         SetActiveCameraDelayedFromDir_401C90();
 
         sActiveHero_507678->field_A8_xpos = field_A8_xpos;
@@ -3719,11 +3719,11 @@ void Elum::VUpdate_4102A0()
                     field_170_flags.Clear(Elum::Flags_170::eFalling_Bit3);
                 }
             }
-            
+
             (this->*sElum_motion_table_4C5148[field_FC_current_motion])();
 
-            if (oldMotion != field_FC_current_motion &&
-                oldMotion == 2 || oldMotion == 11 ||
+            if ((oldMotion != field_FC_current_motion &&
+                oldMotion == 2) || oldMotion == 11 ||
                 oldMotion == 47)
             {
                 LOG_INFO("old motion: " << oldMotion << " | new motion: " << field_FC_current_motion);
@@ -4009,7 +4009,7 @@ Elum* Elum::ctor_410870(int, anythingForTheTimeBeing, anythingForTheTimeBeing, i
     field_12A_brain_state = 0;
 
     field_10A_flags.Set(Flags_10A::e10A_Bit6);
-  
+
 
     field_170_flags.Clear(Elum::Flags_170::eStrugglingWithBees_Bit1);
     field_170_flags.Clear(Elum::Flags_170::eFalling_Bit3);

--- a/Source/AliveLibAO/FallingItem.cpp
+++ b/Source/AliveLibAO/FallingItem.cpp
@@ -194,6 +194,7 @@ void FallingItem::VUpdate_41A120()
         {
             return;
         }
+        [[fallthrough]];
 
     case State::eState_1_GoWaitForDelay:
         field_6_flags.Clear(Options::eCanExplode_Bit7);

--- a/Source/AliveLibAO/HintFly.cpp
+++ b/Source/AliveLibAO/HintFly.cpp
@@ -1584,7 +1584,7 @@ void HintFly::FormWordAndAdvanceToNextWord_42AF90()
 
     const int xBase = field_114_xScreen - (16 * letterCount) / 2;
     const int yBase = field_116_yScreen - 8;
-   
+
     FP xBaseFP = FP_FromInteger(xBase);
     const FP yBaseFP = FP_FromInteger(yBase);
 
@@ -1849,7 +1849,7 @@ void HintFly::VUpdate_42B3D0()
                 field_112_state = State::eIdleWaitForChanting_1;
             }
         }
-        // Fall through
+        [[fallthrough]];
 
     case State::eState_6:
         UpdateParticles_42B1B0();

--- a/Source/AliveLibAO/InvisibleSwitch.cpp
+++ b/Source/AliveLibAO/InvisibleSwitch.cpp
@@ -78,7 +78,7 @@ void InvisibleSwitch::VUpdate_4335A0()
     {
     case 0:
         // sControlledCharacter_50767C can be nullptr during the game ender
-        if (sControlledCharacter_50767C && 
+        if (sControlledCharacter_50767C &&
             sControlledCharacter_50767C->field_A8_xpos >= FP_FromInteger(field_20_top_left.field_0_x) &&
             sControlledCharacter_50767C->field_A8_xpos <= FP_FromInteger(field_24_bottom_right.field_0_x))
         {
@@ -86,12 +86,12 @@ void InvisibleSwitch::VUpdate_4335A0()
                 sControlledCharacter_50767C->field_AC_ypos <= FP_FromInteger(field_24_bottom_right.field_2_y))
             {
                 if (sControlledCharacter_50767C != sActiveHero_507678 ||
-                    sActiveHero_507678->field_FC_current_motion != eAbeStates::State_157_DoorExit_42D780 &&
-                    sActiveHero_507678->field_FC_current_motion != eAbeStates::State_156_DoorEnter_42D370)
+                    (sActiveHero_507678->field_FC_current_motion != eAbeStates::State_157_DoorExit_42D780 &&
+                    sActiveHero_507678->field_FC_current_motion != eAbeStates::State_156_DoorEnter_42D370))
                 {
                     if (field_2C_scale == 2 ||
-                        field_2C_scale == 0 && sControlledCharacter_50767C->field_BC_sprite_scale == FP_FromDouble(0.5) ||
-                        field_2C_scale == 1 && sControlledCharacter_50767C->field_BC_sprite_scale == FP_FromInteger(1))
+                        (field_2C_scale == 0 && sControlledCharacter_50767C->field_BC_sprite_scale == FP_FromDouble(0.5)) ||
+                        (field_2C_scale == 1 && sControlledCharacter_50767C->field_BC_sprite_scale == FP_FromInteger(1)))
                     {
                         field_28_state = 1;
                         field_18_delay_timer = gnFrameCount_507670 + field_1C_delay;

--- a/Source/AliveLibAO/LiftMover.cpp
+++ b/Source/AliveLibAO/LiftMover.cpp
@@ -128,8 +128,8 @@ void LiftMover::VUpdate_4055C0()
         {
             pLiftPoint->Move_435740(FP_FromInteger(0), field_1C_speed, 0);
 
-            if (field_1C_speed > FP_FromInteger(0) && pLiftPoint->OnBottomFloor() ||
-                field_1C_speed < FP_FromInteger(0) && pLiftPoint->OnTopFloor())
+            if ((field_1C_speed > FP_FromInteger(0) && pLiftPoint->OnBottomFloor()) ||
+                (field_1C_speed < FP_FromInteger(0) && pLiftPoint->OnTopFloor()))
             {
                 field_20_state = 2;
             }
@@ -153,8 +153,8 @@ void LiftMover::VUpdate_4055C0()
         {
             pLiftPoint->Move_435740(FP_FromInteger(0), field_1C_speed, 0);
 
-            if (field_1C_speed > FP_FromInteger(0) && pLiftPoint->OnBottomFloor() ||
-                field_1C_speed < FP_FromInteger(0) && pLiftPoint->OnTopFloor())
+            if ((field_1C_speed > FP_FromInteger(0) && pLiftPoint->OnBottomFloor()) ||
+                (field_1C_speed < FP_FromInteger(0) && pLiftPoint->OnTopFloor()))
             {
                 field_20_state = 2;
             }

--- a/Source/AliveLibAO/MainMenu.cpp
+++ b/Source/AliveLibAO/MainMenu.cpp
@@ -405,7 +405,7 @@ void MainMenuFade::VRender_42A7A0(PrimHeader** ppOt)
         ppOt,
         0,
         0);
-    
+
     PSX_RECT rect = {};
     field_10_anim.Get_Frame_Rect_402B50(&rect);
     pScreenManager_4FF7C8->InvalidateRect_406E40(
@@ -517,7 +517,7 @@ MainMenuTransition* MainMenuTransition::ctor_436370(Layer layer, __int16 fadeDir
     field_4_typeId = Types::eDeathFadeOut_80;
 
     gObjList_drawables_504618->Push_Back(this);
-   
+
     field_6_flags.Set(Options::eDrawable_Bit4);
 
     for (int i = 0; i < 2; i++)
@@ -724,9 +724,9 @@ Menu* Menu::ctor_47A6F0(Path_TLV* /*pTlv*/, int tlvInfo)
     ctor_417C10();
     SetVTable(this, 0x4BCE78);
     SetVTable(&field_134_anim, 0x4BA2B8);
-    
+
     gMainMenuInstanceCount_9F2DE0++;
-    
+
     if (sFontLoaded_507688 == 0)
     {
         sFontContext_4FFD68.LoadFontType_41C040(1);
@@ -995,7 +995,7 @@ void Menu::CopyRight_Update_47B4C0()
             gMap_507BA8.SetActiveCam_444660(LevelIds::eMenu_0, 1, 10, CameraSwapEffects::eEffect0_InstantChange, 0, 0);
         }
     }
-    else 
+    else
     {
         if (static_cast<int>(gnFrameCount_507670) > field_1D8_timer || gMap_507BA8.field_4_current_camera != 10)
         {
@@ -1029,7 +1029,7 @@ void Menu::FMV_Select_Update_47E8D0()
                 SFX_Play_43AE60(SoundEffect::MenuNavigation_61, 45, 400, nullptr);
             }
         }
-       
+
         if (Input().IsAnyHeld(InputObject::PadIndex::First, InputCommands::eBack | InputCommands::eHop)) // TODO: Input constants
         {
             // Go back to main screen
@@ -1111,7 +1111,7 @@ void Menu::FMV_Select_Update_47E8D0()
             else
             {
                 const MenuFMV* pRec = &sActiveList_9F2DE4[field_1E0_selected_index];
-                
+
                 field_20E_level = pRec->field_4_level_id;
                 field_210_path = pRec->field_6;
                 field_212_camera =  pRec->field_8;
@@ -1175,14 +1175,14 @@ void NavigateBetweenTwoPoints(FP& a, FP& b)
 
 void Menu::FMV_Or_Level_Select_Render_47EEA0(PrimHeader** ppOt)
 {
-    // Glow hilight 
+    // Glow hilight
     field_134_anim.VRender_403AE0(
         stru_4D00D8.field_0_xpos,
         stru_4D00D8.field_2_ypos,
         ppOt,
         0,
         0);
-    
+
     PSX_RECT rect = {};
     field_134_anim.Get_Frame_Rect_402B50(&rect);
     pScreenManager_4FF7C8->InvalidateRect_406E40(
@@ -1374,7 +1374,7 @@ void Menu::MainScreen_Render_47BED0(PrimHeader** ppOt)
         RenderElement_47A4E0(element.field_0_xpos, element.field_4_ypos, element.field_8_input_command, ppOt, &field_FC_font, &polyOffset);
     }
 }
- 
+
 EXPORT void Menu::MainScreen_Update_47AF60()
 {
     // Calculate idle timers for playing game play demos
@@ -1932,7 +1932,7 @@ void Menu::Load_Render_47DDA0(PrimHeader** ppOt)
 
             const int yAdjust = (FP_GetExponent(field_228 + FP_FromDouble(0.5))) + 26 * start + 120;
             const short text_y = static_cast<short>((yAdjust + FP_GetExponent(FP_FromInteger(-7) * FP_FromInteger(1))) - 1);
-            
+
             BYTE r = 210;
             BYTE g = 150;
             BYTE b = 80;
@@ -2897,7 +2897,7 @@ void Menu::GameSpeak_Update_47CBD0()
     }
 
     field_1CC_fn_update = &Menu::GameSpeakBack_WaitForAbeGoodbye_Update_47D5E0;
-    
+
     if (field_1EC_pObj1)
     {
         field_1EC_pObj1->field_E8_bDestroyOnDone = 1;
@@ -3524,8 +3524,8 @@ void Menu::Load_Update_47D760()
         field_1DC_idle_input_counter++;
     }
 
-    if (Input().IsAnyHeld(InputObject::PadIndex::First, InputCommands::eBack | InputCommands::eHop)
-        && !field_1FE || field_1DC_idle_input_counter > 1000)
+    if ((Input().IsAnyHeld(InputObject::PadIndex::First, InputCommands::eBack | InputCommands::eHop)
+        && !field_1FE) || field_1DC_idle_input_counter > 1000)
     {
         field_1FA = 0;
         field_1E0_selected_index = 1;
@@ -3553,7 +3553,7 @@ void Menu::Load_Update_47D760()
             }
         }
     }
-    else 
+    else
     {
         if (Input().IsAnyPressed(InputObject::PadIndex::First, InputCommands::eDown | InputCommands::eCheatMode))
         {

--- a/Source/AliveLibAO/Map.cpp
+++ b/Source/AliveLibAO/Map.cpp
@@ -122,7 +122,7 @@ struct OpenSeqHandleAE // Same as ::OpenSeqHandle
 };
 ALIVE_ASSERT_SIZEOF(OpenSeqHandleAE, 0x10);
 
-// WARNING: The AO and AE OpenSeqHandle are not memory layout compatible 
+// WARNING: The AO and AE OpenSeqHandle are not memory layout compatible
 // since we use the AE funcs for sound we must use the AE definition here
 OpenSeqHandleAE g_SeqTable_4C9E70[165] =
 {
@@ -475,12 +475,12 @@ void Map::Handle_PathTransition_444DD0()
         field_C_path = pTlv->field_1A_path;
         field_E_camera = pTlv->field_1C_camera;
         field_12_fmv_base_id = pTlv->field_1E_movie;
-       
+
         field_10_screenChangeEffect = kPathChangeEffectToInternalScreenChangeEffect_4CDC78[pTlv->field_20_wipe];
-        
+
         field_18_pAliveObj->field_B2_lvl_number = pTlv->field_18_level;
         field_18_pAliveObj->field_B0_path_number = pTlv->field_1A_path;
-        
+
         // TODO: Probably OG bug, when changing camera/path the TLV pointer can become invalid
         // resulting in a corrupted scale value ?
         // Pointer points to the Path res which is invalid after ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Path, i, TRUE, FALSE);
@@ -588,7 +588,7 @@ void Map::Handle_PathTransition_444DD0()
         auto pCameraName = reinterpret_cast<const CameraName*>(pPathRes + pCamNameOffset);
 
         // Convert the 2 digit camera number string to an integer
-        field_E_camera = 
+        field_E_camera =
             1 * (pCameraName->name[7] - '0') +
             10 * (pCameraName->name[6] - '0');
 
@@ -873,7 +873,7 @@ Path_TLV* Map::Get_First_TLV_For_Offsetted_Camera_4463B0(__int16 cam_x_idx, __in
     {
         return nullptr;
     }
-    
+
     BYTE* pPathData = *field_5C_path_res_array.field_0_pPathRecs[field_2_current_path];
     const int* indexTable = reinterpret_cast<const int*>(pPathData + field_D4_pPathData->field_18_object_index_table_offset);
     const int indexTableEntry = indexTable[(camX + (camY * field_24_max_cams_x))];
@@ -956,7 +956,7 @@ void Map::RestoreBlyData_446A90(const BYTE* pSaveData)
         {
             const PathData* pPathData = pPathRec->field_4_pPathData;
             const int* pIndexTable = reinterpret_cast<const int*>(&(*ppPathRes)[pPathData->field_18_object_index_table_offset]);
-            const int totalCameraCount = 
+            const int totalCameraCount =
                 (pPathData->field_8_bTop - pPathData->field_4_bLeft) / pPathData->field_C_grid_width *
                 ((pPathData->field_A_bBottom - pPathData->field_6_bRight) / pPathData->field_E_grid_height);
 
@@ -1133,13 +1133,13 @@ signed __int16 Map::SetActiveCameraDelayed_444CA0(MapDirections direction, BaseA
         field_C_path = field_2_current_path;
         field_A_level = field_0_current_level;
     }
-    
+
     field_14_direction = direction;
     field_18_pAliveObj = pObj;
     field_1C_cameraSwapEffect = convertedSwapEffect;
     field_6_state = 1;
     sMap_bDoPurpleLightEffect_507C9C = 0;
-    
+
     if (field_1C_cameraSwapEffect == CameraSwapEffects::eEffect5_1_FMV || field_1C_cameraSwapEffect == CameraSwapEffects::eEffect11)
     {
         sMap_bDoPurpleLightEffect_507C9C = 1;
@@ -1154,7 +1154,7 @@ __int16 Map::Is_Point_In_Current_Camera_4449C0(int level, int path, FP xpos, FP 
     {
         return FALSE;
     }
-    
+
     PSX_RECT rect = {};
     rect.x = FP_GetExponent(xpos);
     rect.w = FP_GetExponent(xpos);
@@ -1337,7 +1337,7 @@ EXPORT Path_TLV* Map::TLV_Get_At_446260(__int16 xpos, __int16 ypos, __int16 widt
 
     const int grid_cell_y = top / field_D4_pPathData->field_E_grid_height;
     const int grid_cell_x = (right / field_D4_pPathData->field_C_grid_width);
-   
+
     // Check within map bounds
     if (grid_cell_x >= field_24_max_cams_x)
     {
@@ -1427,7 +1427,7 @@ Path_TLV* Map::TLV_Get_At_446060(Path_TLV* pTlv, FP xpos, FP ypos, FP width, FP 
         pTlv = reinterpret_cast<Path_TLV*>(&ppPathRes[pPathData->field_14_object_offset + indexTableEntry]);
         pTlv->RangeCheck();
 
-        if (!bContinue || 
+        if (!bContinue ||
             (xpos_converted <= pTlv->field_14_bottom_right.field_0_x &&
              width_converted >= pTlv->field_10_top_left.field_0_x &&
              height_converted >= pTlv->field_10_top_left.field_2_y &&
@@ -1447,7 +1447,7 @@ Path_TLV* Map::TLV_Get_At_446060(Path_TLV* pTlv, FP xpos, FP ypos, FP width, FP 
         pTlv = Path_TLV::Next_446460(pTlv);
         pTlv->RangeCheck();
 
-        if (!bContinue|| 
+        if (!bContinue||
             (xpos_converted <= pTlv->field_14_bottom_right.field_0_x &&
             width_converted >= pTlv->field_10_top_left.field_0_x &&
             height_converted >= pTlv->field_10_top_left.field_2_y &&
@@ -1714,7 +1714,7 @@ void Map::GoTo_Camera_445050()
     if (field_A_level != field_0_current_level)
     {
         ResourceManager::LoadingLoop_41EAD0(bShowLoadingIcon);
-        
+
         // Free all cameras
         for (int i = 0; i < ALIVE_COUNTOF(field_34_camera_array); i++)
         {
@@ -1801,10 +1801,10 @@ void Map::GoTo_Camera_445050()
     field_D4_pPathData = pPathRecord->field_4_pPathData;
     field_24_max_cams_x = (field_D4_pPathData->field_8_bTop - field_D4_pPathData->field_4_bLeft) / field_D4_pPathData->field_C_grid_width;
     field_26_max_cams_y = (field_D4_pPathData->field_A_bBottom - field_D4_pPathData->field_6_bRight) / field_D4_pPathData->field_E_grid_height;
-    
+
     char camNameBuffer[20] = {};
     Path_Format_CameraName_4346B0(camNameBuffer, field_A_level, field_C_path, field_E_camera);
-    
+
     const auto totalCams = field_26_max_cams_y * field_24_max_cams_x;
 
     int camIdx = 0;
@@ -1824,7 +1824,7 @@ void Map::GoTo_Camera_445050()
 
     const auto camX_idx = static_cast<short>(camIdx % field_24_max_cams_x);
     const auto camY_idx = static_cast<short>(camIdx / field_24_max_cams_x);
-  
+
     field_20_camX_idx = camX_idx;
     field_22_camY_idx = camY_idx;
 
@@ -1913,7 +1913,7 @@ void Map::GoTo_Camera_445050()
         pScreenManager_4FF7C8 = ao_new<ScreenManager>();
         pScreenManager_4FF7C8->ctor_406830(field_34_camera_array[0]->field_C_ppBits, &field_2C_camera_offset);
     }
-    
+
     Loader_446590(field_20_camX_idx, field_22_camY_idx, LoadMode::Mode_0, TlvTypes::None_m1); // none = load all
 
     if (old_current_path != field_2_current_path || old_current_level != field_0_current_level)
@@ -1928,7 +1928,7 @@ void Map::GoTo_Camera_445050()
             gElum_507680->VCheckCollisionLineStillValid(10);
         }
     }
-    
+
     Create_FG1s_4447D0();
 
     if (field_10_screenChangeEffect == CameraSwapEffects::eEffect5_1_FMV)
@@ -1941,7 +1941,7 @@ void Map::GoTo_Camera_445050()
         pScreenManager_4FF7C8->DecompressCameraToVRam_407110(reinterpret_cast<unsigned short**>(field_34_camera_array[0]->field_C_ppBits));
         pScreenManager_4FF7C8->InvalidateRect_406CC0(0, 0, 640, 240);
         pScreenManager_4FF7C8->MoveImage_406C40();
-        pScreenManager_4FF7C8->field_36_flags = pScreenManager_4FF7C8->field_36_flags & ~1 ^ 1;
+        pScreenManager_4FF7C8->field_36_flags = (pScreenManager_4FF7C8->field_36_flags & ~1) ^ 1;
     }
 
     if (field_10_screenChangeEffect != CameraSwapEffects::eEffect5_1_FMV && field_10_screenChangeEffect != CameraSwapEffects::eEffect11)

--- a/Source/AliveLibAO/Mine.cpp
+++ b/Source/AliveLibAO/Mine.cpp
@@ -71,7 +71,7 @@ Mine* Mine::ctor_43A330(Path_Mine* pTlv, int tlvInfo)
     field_10E_disabled_resources = pTlv->field_1E_disabled_resources;
 
     // TODO
-    field_1B0_flags = 2 * (pTlv->field_20_persists_offscreen == Choice_short::eYes_1) | field_1B0_flags & ~2;
+    field_1B0_flags = 2 * (pTlv->field_20_persists_offscreen == Choice_short::eYes_1) | (field_1B0_flags & ~2);
 
     ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kAbebombResID, 1, 0);
     ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kDebrisID00, 1, 0);

--- a/Source/AliveLibAO/MusicController.cpp
+++ b/Source/AliveLibAO/MusicController.cpp
@@ -169,7 +169,7 @@ const MusicController_Record array_3_stru_4CDB58[] =
     { 67, 0, 16, 0, 0, 0, 0 },
     { 31, 0, 16, 0, 0, 0, 0 },
 
-    // TODO: Are these part of something else? 
+    // TODO: Are these part of something else?
     { 20, 20, 1310736, 16, 16, 16, 1 },
     { 20, 16, 65556, 1, 20, 16, 16 }
 };
@@ -703,7 +703,7 @@ void MusicController::PlayMusic_443460(MusicTypes musicType, BaseGameObject* pOb
             return;
         }
 
-        if (pObj == field_1C_pObj || !field_1C_pObj || !field_20 && (a4 || musicType >= field_3A_type))
+        if (pObj == field_1C_pObj || !field_1C_pObj || (!field_20 && (a4 || musicType >= field_3A_type)))
         {
             field_1C_pObj = pObj;
             field_20 = a4;
@@ -798,7 +798,7 @@ void MusicController::UpdateMusic_442C20()
             break;
 
         case MusicTypes::eChase_4:
-            // Fall through
+            [[fallthrough]];
         case MusicTypes::eSlogChase_5:
         {
             const MusicController_Record* pRec = field_3A_type == MusicTypes::eChase_4 ?
@@ -861,7 +861,7 @@ void MusicController::UpdateMusic_442C20()
             break;
 
         case MusicTypes::eType9:
-            // Fall through
+            [[fallthrough]];
 
         case MusicTypes::eType10:
             idx = field_3A_type == MusicTypes::eType9 ? 121 : 122;
@@ -938,7 +938,7 @@ void MusicController::UpdateMusic_442C20()
             break;
 
         case MusicTypes::eSecretAreaShort_15:
-            // Fall through
+            [[fallthrough]];
 
         case MusicTypes::eSecretAreaLong_16:
             if (field_3A_type == MusicTypes::eSecretAreaShort_15)

--- a/Source/AliveLibAO/Paramite.cpp
+++ b/Source/AliveLibAO/Paramite.cpp
@@ -260,7 +260,7 @@ BaseGameObject* Paramite::dtor_44AB00()
     }
 
     SND_Seq_Stop_477A60(SeqId::eParamiteNearby_30);
-    
+
     MusicController::PlayMusic_443810(MusicController::MusicTypes::eType0, this, 0, 0);
 
     return dtor_401000();
@@ -584,7 +584,7 @@ void Paramite::VUpdate_44A490()
         field_10_anim.field_4_flags.Set(AnimFlags::eBit2_Animate);
         field_10_anim.field_4_flags.Set(AnimFlags::eBit3_Render);
 
-       
+
         const auto oldMotion = field_FC_current_motion;
         field_110_state = (this->*field_10C_fn)();
 
@@ -607,9 +607,9 @@ void Paramite::VUpdate_44A490()
 
         const FP oldx = field_A8_xpos;
         const FP oldy = field_AC_ypos;
-        
+
         (this->*sParamiteMotionTable_4CDCB0[field_FC_current_motion])();
-        
+
         if (oldx != field_A8_xpos || oldy != field_AC_ypos)
         {
             field_F0_pTlv = gMap_507BA8.TLV_Get_At_446060(
@@ -661,7 +661,7 @@ void Paramite::ToIdle_44B580()
     field_124_XSpeed = FP_FromInteger(0);
     field_B4_velx = FP_FromInteger(0);
     field_B8_vely = FP_FromInteger(0);
-    
+
     field_FC_current_motion = eParamiteStates::State_0_Idle_44B900;
 
     MapFollowMe_401D30(TRUE);
@@ -790,7 +790,7 @@ void Paramite::ToKnockBack_44B5B0()
 {
     const FP nextX = field_A8_xpos - field_B4_velx;
     field_A8_xpos = FP_FromInteger((FP_GetExponent(nextX) & 0xFC00) + SnapToXGrid_41FAA0(field_BC_sprite_scale, FP_GetExponent(nextX) & 0x3FF));
-    
+
     MapFollowMe_401D30(1);
 
     if (field_B8_vely < FP_FromInteger(0))
@@ -1217,7 +1217,7 @@ __int16 Paramite::Brain_Patrol_447A10()
         field_FE_next_state = eParamiteStates::State_0_Idle_44B900;
         field_128_never_read = 1;
         return AI_Patrol::eState0_IdleForAbe_1;
-   
+
     case AI_Patrol::eState0_RunningFromAbe_3:
         if (!VOnSameYLevel(sActiveHero_507678) || field_BC_sprite_scale != sActiveHero_507678->field_BC_sprite_scale)
         {
@@ -1478,7 +1478,7 @@ __int16 Paramite::Brain_Patrol_447A10()
             field_148_pMeat->field_C_refCount++;
             return 0;
         }
-        
+
         if (VOnSameYLevel(sActiveHero_507678)
             && field_BC_sprite_scale == sActiveHero_507678->field_BC_sprite_scale
             && !WallHit_401930(field_BC_sprite_scale * FP_FromInteger(5), sActiveHero_507678->field_A8_xpos - field_A8_xpos))
@@ -1534,7 +1534,7 @@ __int16 Paramite::Brain_Patrol_447A10()
         }
         field_FE_next_state = eParamiteStates::State_15_Hiss_44D300;
         return field_110_state;
- 
+
     default:
         return field_110_state;
     }
@@ -1650,7 +1650,7 @@ __int16 Paramite::Brain_SurpriseWeb_448D00()
         {
             field_B8_vely += (field_BC_sprite_scale * FP_FromDouble(0.5));
             return field_110_state;
-            
+
         }
         return AI_SurpriseWeb::eState3_StateLoop2_5;
 
@@ -2073,7 +2073,7 @@ __int16 Paramite::Brain_ChasingAbe_449170()
                 field_FE_next_state = eParamiteStates::State_6_Hop_44CB20;
                 return AI_ChasingAbe::eState2_Jumping_8;
             }
-        } 
+        }
         else if (!field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX))
         {
             if (Check_IsOnEndOfLine_4021A0(0, 1))
@@ -2699,8 +2699,8 @@ void Paramite::State_0_Idle_44B900()
     }
 }
 
-const FP sWalkBeginVelTable_4BBC88[3] = 
-{ 
+const FP sWalkBeginVelTable_4BBC88[3] =
+{
     FP_FromInteger(0),
     FP_FromDouble(1.40),
     FP_FromDouble(9.02)
@@ -2781,7 +2781,7 @@ void Paramite::State_2_Walking_44B9E0()
     switch (field_10_anim.field_92_current_frame)
     {
     case 0:
-        // Fall through
+        [[fallthrough]];
     case 7:
         Sound_44DBB0(field_10_anim.field_92_current_frame == 7 ? 3 : 4);
 
@@ -2797,7 +2797,7 @@ void Paramite::State_2_Walking_44B9E0()
         break;
 
     case 3:
-        // Fall through
+        [[fallthrough]];
     case 10:
         if (field_FE_next_state == eParamiteStates::State_3_Running_44C070)
         {
@@ -3147,7 +3147,7 @@ void Paramite::State_6_Hop_44CB20()
                 break;
             }
         }
-       
+
         if (field_AC_ypos - field_E8_LastLineYPos > FP_FromInteger(5))
         {
             field_124_XSpeed = FP_FromDouble(0.75);
@@ -3166,8 +3166,8 @@ void Paramite::State_6_Hop_44CB20()
     }
 }
 
-const FP State_7_Unknown_VelTable_4BBCA8[2] = 
-{ 
+const FP State_7_Unknown_VelTable_4BBCA8[2] =
+{
     FP_FromDouble(2.25),
     FP_FromDouble(5.63)
 };
@@ -3202,8 +3202,8 @@ void Paramite::State_7_Unknown_44BF10()
     }
 }
 
-const FP sWalkRunTransVelTable_4BBD18[3] = 
-{ 
+const FP sWalkRunTransVelTable_4BBD18[3] =
+{
     FP_FromDouble(5.39),
     FP_FromDouble(5.39),
     FP_FromDouble(5.39)
@@ -3237,8 +3237,8 @@ void Paramite::State_8_WalkRunTransition_44C790()
     }
 }
 
-const FP sWalkEndVelTable_4BBC98[3] = 
-{ 
+const FP sWalkEndVelTable_4BBC98[3] =
+{
     FP_FromDouble(2.33),
     FP_FromDouble(5.03),
     FP_FromDouble(6.70)
@@ -3273,8 +3273,8 @@ void Paramite::State_9_WalkEnd_44BDE0()
     ToIdle_44B580();
 }
 
-const FP sRunBeginVelTable_4BBCF8[3] = 
-{ 
+const FP sRunBeginVelTable_4BBCF8[3] =
+{
     FP_FromDouble(1.87),
     FP_FromDouble(2.15),
     FP_FromDouble(3.33)
@@ -3310,8 +3310,8 @@ void Paramite::State_10_RunBegin_44C4C0()
     }
 }
 
-const FP sRunEndVelTable_4BBD08[3] = 
-{ 
+const FP sRunEndVelTable_4BBD08[3] =
+{
     FP_FromDouble(3.11),
     FP_FromDouble(3.06),
     FP_FromDouble(3.43)
@@ -3808,7 +3808,7 @@ void Paramite::State_22_Unknown_44D8F0()
     {
         sActiveHero_507678->VTakeDamage(this);
     }
-    
+
     if (field_10_anim.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame))
     {
         field_FC_current_motion = eParamiteStates::State_14_PreHiss_44D170;

--- a/Source/AliveLibAO/PauseMenu.cpp
+++ b/Source/AliveLibAO/PauseMenu.cpp
@@ -147,7 +147,7 @@ ALIVE_VAR(1, 0x5080C6, saveName, saveNameBuffer_5080C6, {});
 
 const char *gLevelNames_4CE1D4[20] =
 {
-    "¸",
+    "ï¿½",
     "RuptureFarms",
     "Monsaic Lines",
     "Paramonia",
@@ -429,7 +429,7 @@ void PauseMenu::VUpdate_44DFB0()
                         {
                             if (strspn(lastPressedKeyNT, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 !-"))
                             {
-                                if (lastPressedKeyNT[0] != 32 || string_len_no_nullterminator != 1 && saveNameBuffer_5080C6.characters[string_len_no_nullterminator] != lastPressedKeyNT[0])
+                                if (lastPressedKeyNT[0] != 32 || (string_len_no_nullterminator != 1 && saveNameBuffer_5080C6.characters[string_len_no_nullterminator] != lastPressedKeyNT[0]))
                                 {
                                     if (string_len_no_nullterminator > 19)
                                     {

--- a/Source/AliveLibAO/PauseMenu.cpp
+++ b/Source/AliveLibAO/PauseMenu.cpp
@@ -147,7 +147,7 @@ ALIVE_VAR(1, 0x5080C6, saveName, saveNameBuffer_5080C6, {});
 
 const char *gLevelNames_4CE1D4[20] =
 {
-    "�",
+    "¸",
     "RuptureFarms",
     "Monsaic Lines",
     "Paramonia",

--- a/Source/AliveLibAO/Primitives.cpp
+++ b/Source/AliveLibAO/Primitives.cpp
@@ -20,7 +20,7 @@ void CC Poly_Set_Blending_498A00(PrimHeader* pPrim, int bBlending)
 
 int CC PSX_getClut_496840(int x, int y)
 {
-    return (y << 6) | (x >> 4) & 63;
+    return (y << 6) | ((x >> 4) & 63);
 }
 
 void CC Poly_Set_SemiTrans_498A40(PrimHeader* pPrim, int bSemiTrans)

--- a/Source/AliveLibAO/Scrab.cpp
+++ b/Source/AliveLibAO/Scrab.cpp
@@ -112,7 +112,7 @@ Scrab* Scrab::ctor_45B5F0(Path_Scrab* pTlv, int tlvInfo)
     SetVTable(this, 0x4BC710);
 
     field_4_typeId = Types::eScrab_77;
-    
+
     for (int i = 0; i < ALIVE_COUNTOF(field_150_resources); i++)
     {
         field_150_resources[i] = nullptr;
@@ -130,7 +130,7 @@ Scrab* Scrab::ctor_45B5F0(Path_Scrab* pTlv, int tlvInfo)
     field_150_resources[3] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kArsskwrResID, 1, 0);
     field_150_resources[4] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kArswhirlResID, 1, 0);
     field_150_resources[13] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kArscrshResID, 1, 0);
-    
+
     Animation_Init_417FD0(
         168644,
         168,
@@ -138,12 +138,12 @@ Scrab* Scrab::ctor_45B5F0(Path_Scrab* pTlv, int tlvInfo)
         field_150_resources[0],
         1);
 
-    
+
     field_10A_flags.Set(Flags_10A::e10A_Bit4_SetOffExplosives);
 
     field_132_res_block_idx = 0;
     field_118_timer = 0;
-    
+
     SetBrain(&Scrab::Brain_Patrol_460020);
 
     field_110_brain_ret = 0;
@@ -182,7 +182,7 @@ Scrab* Scrab::ctor_45B5F0(Path_Scrab* pTlv, int tlvInfo)
 
     field_138_attack_duration = pTlv->field_26_attack_duration;
 
-    field_188_flags = 32 * ( pTlv->field_2A_roar_randomly & 1) | (field_188_flags & ~0x11 | 4) & ~0x28;
+    field_188_flags = 32 * ( pTlv->field_2A_roar_randomly & 1) | ((field_188_flags & ~0x11 | 4) & ~0x28);
 
     FP hitX = {};
     FP hitY = {};
@@ -333,7 +333,7 @@ void Scrab::VUpdate_45B360()
             field_188_flags |= 8u;
         }
     }
-    
+
     const FP hero_xd = FP_Abs(field_A8_xpos - sActiveHero_507678->field_A8_xpos);
     const FP hero_yd = FP_Abs(field_AC_ypos - sActiveHero_507678->field_AC_ypos);
 
@@ -360,7 +360,7 @@ void Scrab::VUpdate_45B360()
             field_10_anim.field_4_flags.Set(AnimFlags::eBit2_Animate);
             field_10_anim.field_4_flags.Set(AnimFlags::eBit3_Render);
         }
-        
+
         const auto old_motion = field_FC_current_motion;
 
         field_110_brain_ret = (this->*field_10C_fn)();
@@ -1351,8 +1351,8 @@ void Scrab::State_4_Turn_45EF30()
     }
 }
 
-const FP sRunToStandVelTable_4BC838[10] = 
-{ 
+const FP sRunToStandVelTable_4BC838[10] =
+{
     FP_FromDouble(7.49),
     FP_FromDouble(6.91),
     FP_FromDouble(3.88),
@@ -1423,12 +1423,12 @@ void Scrab::State_5_RunToStand_45ED90()
     }
 }
 
-const FP sHopBeginVelTable_4BC860[4] = 
-{ 
+const FP sHopBeginVelTable_4BC860[4] =
+{
     FP_FromDouble(9.88),
     FP_FromDouble(10.10),
     FP_FromDouble(10.10),
-    FP_FromDouble(9.88) 
+    FP_FromDouble(9.88)
 };
 
 void Scrab::State_6_HopBegin_45F3C0()
@@ -1472,8 +1472,8 @@ void Scrab::State_6_HopBegin_45F3C0()
     }
 }
 
-const FP sHopMidAirVelTable_4BC870[8] = 
-{ 
+const FP sHopMidAirVelTable_4BC870[8] =
+{
     FP_FromDouble(9.45),
     FP_FromDouble(8.81),
     FP_FromDouble(8.11),
@@ -1555,8 +1555,8 @@ void Scrab::State_7_HopMidair_45F1A0()
     }
 }
 
-const FP sLandVelXTable_4BC890[4] = 
-{ 
+const FP sLandVelXTable_4BC890[4] =
+{
     FP_FromDouble(6.10),
     FP_FromDouble(6.07),
     FP_FromDouble(6.13),
@@ -1659,7 +1659,7 @@ void Scrab::State_9_JumpToFall_45EFD0()
     }
 }
 
-const FP sStandToWalkVelTable_4BC778[3] = 
+const FP sStandToWalkVelTable_4BC778[3] =
 {
     FP_FromDouble(1.11),
     FP_FromDouble(2.36),
@@ -1697,8 +1697,8 @@ void Scrab::State_10_StandToWalk_45E670()
     }
 }
 
-const FP sStandToRunVel_4BC7F0[3] = 
-{ 
+const FP sStandToRunVel_4BC7F0[3] =
+{
     FP_FromDouble(2.29),
     FP_FromDouble(2.69),
     FP_FromDouble(3.87)
@@ -1733,8 +1733,8 @@ void Scrab::State_11_StandToRun_45E9F0()
     }
 }
 
-const FP sWalkToStandVel_4BC7E0[3] = 
-{ 
+const FP sWalkToStandVel_4BC7E0[3] =
+{
     FP_FromDouble(1.04),
     FP_FromDouble(3.29),
     FP_FromDouble(2.85)
@@ -1756,7 +1756,7 @@ void Scrab::State_12_WalkToStand_45E930()
         ToStand();
     }
 
-    MoveOnLine_45E450(); 
+    MoveOnLine_45E450();
 
     if (field_FC_current_motion == eScrabStates::State_12_WalkToStand_45E930 && field_10_anim.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame) && !ToNextMotion_45DFB0())
     {
@@ -1861,8 +1861,8 @@ void Scrab::State_13_RunJumpBegin_45F5D0()
     }
 }
 
-const FP sRunJumpEndVelTable_4BC8C0[4] = 
-{ 
+const FP sRunJumpEndVelTable_4BC8C0[4] =
+{
     FP_FromDouble(4.18),
     FP_FromDouble(4.14),
     FP_FromDouble(4.21),
@@ -2262,7 +2262,7 @@ __int16 Scrab::Brain_Fighting_45C370()
                 }
                 field_FE_next_state = eScrabStates::State_20_HowlBegin_45FA60;
                 return 7;
-              
+
             }
             else
             {
@@ -3522,7 +3522,7 @@ __int16 Scrab::Brain_Patrol_460020()
             field_118_timer = gnFrameCount_507670 + 30;
             return 7;
         }
-        
+
         field_FE_next_state = GetMotionForPatrolType(field_116_patrol_type);
         return 4;
 
@@ -3954,8 +3954,8 @@ __int16 Scrab::HandleRunning()
 
     if (pStopper)
     {
-        if (pStopper->field_18_direction == Path_EnemyStopper::StopDirection::Left_0 && field_120_pTarget->field_A8_xpos < field_A8_xpos ||
-            pStopper->field_18_direction == Path_EnemyStopper::StopDirection::Right_1 && field_120_pTarget->field_A8_xpos > field_A8_xpos ||
+        if ((pStopper->field_18_direction == Path_EnemyStopper::StopDirection::Left_0 && field_120_pTarget->field_A8_xpos < field_A8_xpos) ||
+            (pStopper->field_18_direction == Path_EnemyStopper::StopDirection::Right_1 && field_120_pTarget->field_A8_xpos > field_A8_xpos) ||
             pStopper->field_18_direction == Path_EnemyStopper::StopDirection::Both_2)
         {
             if (!SwitchStates_Get(pStopper->field_1A_id))

--- a/Source/AliveLibAO/Slig.cpp
+++ b/Source/AliveLibAO/Slig.cpp
@@ -394,7 +394,7 @@ Slig* Slig::ctor_464D40(Path_Slig* pTlv, int tlvInfo)
     MapFollowMe_401D30(TRUE);
 
     Init_46B890();
-    
+
     VStackOnObjectsOfType(Types::eSlig_88);
 
     field_10A_flags.Set(Flags_10A::e10A_Bit6);
@@ -496,7 +496,7 @@ void Slig::VScreenChanged_465480()
 {
     if (gMap_507BA8.field_0_current_level != gMap_507BA8.field_A_level
         || gMap_507BA8.field_28_cd_or_overlay_num != gMap_507BA8.GetOverlayId_4440B0()
-        || gMap_507BA8.field_2_current_path != gMap_507BA8.field_C_path && this != sControlledCharacter_50767C)
+        || (gMap_507BA8.field_2_current_path != gMap_507BA8.field_C_path && this != sControlledCharacter_50767C))
     {
         field_6_flags.Set(BaseGameObject::eDead_Bit3);
     }
@@ -667,7 +667,7 @@ void Slig::Init_46B890()
                         field_1F4_points_count++;
                     }
                 }
-                
+
                 pTlvIter = Path_TLV::Next_446460(pTlvIter);
             }
         }
@@ -755,7 +755,7 @@ void Slig::VUpdate_465050()
             field_B4_velx = FP_FromInteger(0);
             field_B8_vely = FP_FromInteger(0);
         }
-        
+
         SetActiveCameraDelayedFromDir_401C90();
 
         field_E8_LastLineYPos = field_AC_ypos;
@@ -763,7 +763,7 @@ void Slig::VUpdate_465050()
     else
     {
         const auto old_motion = field_FC_current_motion;
-        
+
         const auto oldBrain = field_1F8_fn;
 
         field_10E_brain_state = (this->*field_1F8_fn)();
@@ -790,7 +790,7 @@ void Slig::VUpdate_465050()
 
         const FP new_x = field_A8_xpos;
         const FP new_y = field_AC_ypos;
-        
+
         (this->*sSligMotionTable_4CF960[field_FC_current_motion])();
 
         if (new_x != field_A8_xpos || new_y != field_AC_ypos)
@@ -818,7 +818,7 @@ void Slig::VUpdate_465050()
         else if (field_11E)
         {
             field_FC_current_motion = field_E4_previous_motion;
-            
+
             VUpdateAnimData_464D00();
 
             field_10_anim.SetFrame_402AC0(field_E6_last_anim_frame);
@@ -2532,8 +2532,8 @@ signed __int16 Slig::MainMovement_467020()
     default:
         if (field_FE_next_state < eSligStates::State_21_SpeakHereBoy_467BD0 || field_FE_next_state > eSligStates::State_32_Blurgh_468410)
         {
-            if (field_FE_next_state == eSligStates::State_13_Reload_4687B0 
-                || field_FE_next_state == eSligStates::State_46_PullLever_46A590 
+            if (field_FE_next_state == eSligStates::State_13_Reload_4687B0
+                || field_FE_next_state == eSligStates::State_46_PullLever_46A590
                 || field_FE_next_state == eSligStates::State_52_Beat_46AA90
                 )
             {
@@ -2704,7 +2704,7 @@ void Slig::State_2_Walking_469130()
             }
             break;
         case 11:
-            
+
             if (field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX))
             {
                 v12 = -(ScaleToGridSize_41FA30(field_BC_sprite_scale));
@@ -2732,8 +2732,8 @@ void Slig::State_2_Walking_469130()
             }
             else
             {
-                if (field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594)
-                    || field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590)
+                if ((field_B4_velx > FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Left_4C6594))
+                    || (field_B4_velx < FP_FromInteger(0) && Input().IsAnyPressed(sInputKey_Right_4C6590))
                     || !(Input().IsAnyPressed(sInputKey_Right_4C6590 | sInputKey_Left_4C6594)))
                 {
                     field_FC_current_motion = eSligStates::State_19_WalkToStand_469610;
@@ -3185,8 +3185,8 @@ void Slig::State_9_SlidingToStand_469DF0()
                     MainMovement_467020();
                 }
             }
-            else if (field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Right_4C6590)
-                || !(field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX)) && Input().IsAnyPressed(sInputKey_Left_4C6594))
+            else if ((field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX) && Input().IsAnyPressed(sInputKey_Right_4C6590))
+                || (!(field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX)) && Input().IsAnyPressed(sInputKey_Left_4C6594)))
             {
                 field_E4_previous_motion = eSligStates::State_10_SlidingTurn_469F10;
                 field_E6_last_anim_frame = field_10_anim.field_92_current_frame;
@@ -3568,7 +3568,7 @@ void Slig::State_34_SleepingToStand_46A5F0()
     {
         Slig_SoundEffect_46F310(SligSfx::eToStand_0);
     }
-    
+
     if (field_10_anim.field_92_current_frame == 9)
     {
         Slig_SoundEffect_46F310(SligSfx::eWalkingStep_2);
@@ -3635,7 +3635,7 @@ void Slig::State_35_Knockback_46A720()
             field_128_timer = gnFrameCount_507670 + 10;
         }
     }
-    
+
     Event_Broadcast_417220(kEventNoise_0, this);
 
     if ((gMap_507BA8.field_0_current_level == LevelIds::eRuptureFarms_1
@@ -3665,7 +3665,7 @@ void Slig::State_35_Knockback_46A720()
 void Slig::State_36_KnockbackToStand_46A7F0()
 {
     Event_Broadcast_417220(kEventNoise_0, this);
-    
+
     if (field_10_anim.field_92_current_frame >= 2 && field_10_anim.field_92_current_frame <= 10)
     {
         Slig_SoundEffect_46F310(SligSfx::eToStand_0);
@@ -3710,7 +3710,7 @@ void Slig::State_36_KnockbackToStand_46A7F0()
             {
                  field_A8_xpos += (field_BC_sprite_scale * field_BC_sprite_scale) * FP_FromInteger(13);
             }
-           
+
             break;
 
         case 11:
@@ -4030,7 +4030,7 @@ void Slig::State_49_LiftGrip_4663A0()
             }
             return;
         }
-        
+
         if (Input().IsAnyPressed(sInputKey_Down_4C659C))
         {
             if (pLiftPoint->OnBottomFloor())
@@ -4356,8 +4356,8 @@ __int16 Slig::Brain_Unknown_46B250()
             field_A8_xpos,
             field_AC_ypos,
             0)
-        || field_20E_spotted_possessed_slig
-        && sControlledCharacter_50767C->field_4_typeId == Types::eSlig_88
+        || (field_20E_spotted_possessed_slig
+        && sControlledCharacter_50767C->field_4_typeId == Types::eSlig_88)
         || Event_Get_417250(kEventResetting_6))
     {
         if (!VOnSameYLevel(
@@ -5003,13 +5003,13 @@ __int16 Slig::Brain_Chasing_46CD60()
 
     if (field_B0_path_number != gMap_507BA8.field_2_current_path
         || field_B2_lvl_number != gMap_507BA8.field_0_current_level
-        || Event_Get_417250(kEventDeathReset_4)
+        || (Event_Get_417250(kEventDeathReset_4)
         && !gMap_507BA8.Is_Point_In_Current_Camera_4449C0(
             field_B2_lvl_number,
             field_B0_path_number,
             field_A8_xpos,
             field_AC_ypos,
-            0))
+            0)))
     {
         field_6_flags.Set(BaseGameObject::eDead_Bit3);
     }
@@ -5171,10 +5171,10 @@ __int16 Slig::Brain_Idle_46D6E0()
                 if (pTlv)
                 {
                     FP kScaleGrid = ScaleToGridSize_41FA30(field_BC_sprite_scale);
-                    if (FP_FromInteger(FP_GetExponent(field_A8_xpos) - pTlv->field_10_top_left.field_0_x) < kScaleGrid &&
-                        !(field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX)) ||
-                        FP_FromInteger(pTlv->field_14_bottom_right.field_0_x - FP_GetExponent(field_A8_xpos)) < kScaleGrid &&
-                        field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX))
+                    if ((FP_FromInteger(FP_GetExponent(field_A8_xpos) - pTlv->field_10_top_left.field_0_x) < kScaleGrid &&
+                        !(field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX))) ||
+                        (FP_FromInteger(pTlv->field_14_bottom_right.field_0_x - FP_GetExponent(field_A8_xpos)) < kScaleGrid &&
+                        field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX)))
                     {
                         auto pSwitch = static_cast<Switch*>(FindObjectOfType_418280(
                             Types::eLever_97,
@@ -5568,7 +5568,7 @@ __int16 Slig::Brain_GetAlerted_46E800()
             field_A8_xpos,
             field_AC_ypos,
             0)
-        || sControlledCharacter_50767C->field_4_typeId == Types::eSlig_88 && field_20E_spotted_possessed_slig
+        || (sControlledCharacter_50767C->field_4_typeId == Types::eSlig_88 && field_20E_spotted_possessed_slig)
         || IsAbeEnteringDoor_46BEE0(sControlledCharacter_50767C)
         || Event_Get_417250(kEventResetting_6))
     {
@@ -5707,7 +5707,7 @@ __int16 Slig::Brain_BeatingUp_46EC40()
         field_FE_next_state = eSligStates::State_28_SpeakBullshit2_468110;
         return 129;
     }
-    
+
     WaitOrWalk_46E440();
     return 129;
 }

--- a/Source/AliveLibAO/Slog.cpp
+++ b/Source/AliveLibAO/Slog.cpp
@@ -380,7 +380,7 @@ __int16 Slog::VTakeDamage_473610(BaseGameObject* pFrom)
     case Types::eRockSpawner_32:
     case Types::eRollingBall_72:
         Slog::Sfx_475BD0(9);
-        // Fall through
+        [[fallthrough]];
 
     case Types::eElectrocute_103:
         field_100_health = FP_FromInteger(0);
@@ -597,7 +597,7 @@ void Slog::Init_473130()
     field_184_resources[2] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kDogattkResID, 1, 0);
     field_184_resources[3] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kDogknfdResID, 1, 0);
     field_184_resources[4] = ResourceManager::GetLoadedResource_4554F0(ResourceManager::Resource_Animation, ResourceID::kDogidleResID, 1, 0);
-    
+
     Animation_Init_417FD0(
         94456,
         121,
@@ -751,7 +751,7 @@ void Slog::ToJump_473FB0()
     field_E8_LastLineYPos = field_AC_ypos;
 
     field_FC_current_motion = eSlogStates::State_19_JumpForwards_475610;
-    
+
     VOnTrapDoorOpen();
 
     field_F4_pLine = nullptr;
@@ -1359,7 +1359,7 @@ void Slog::State_6_MoveHeadUpwards_474220()
         {
             Sfx_475BD0(4);
         }
-        
+
         ToIdle();
     }
 }
@@ -1396,7 +1396,7 @@ void Slog::State_7_SlideTurn_474DB0()
     }
 
 
-    if (WallHit_401930(field_BC_sprite_scale * FP_FromInteger(20), field_B4_velx) || 
+    if (WallHit_401930(field_BC_sprite_scale * FP_FromInteger(20), field_B4_velx) ||
         field_10_anim.field_4_flags.Get(AnimFlags::eBit18_IsLastFrame))
     {
         ToIdle();
@@ -1478,7 +1478,7 @@ void Slog::State_9_StartWalking_474690()
     if (WallHit_401930(field_BC_sprite_scale * FP_FromInteger(20), field_B4_velx))
     {
         ToIdle();
-        
+
         if (field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX))
         {
             field_A8_xpos += field_B4_velx + (ScaleToGridSize_41FA30(field_BC_sprite_scale) /  FP_FromInteger(2));
@@ -1512,7 +1512,7 @@ void Slog::State_10_EndWalking_4747D0()
 
         if (field_10_anim.field_4_flags.Get(AnimFlags::eBit5_FlipX))
         {
-            field_A8_xpos += field_B4_velx + (ScaleToGridSize_41FA30(field_BC_sprite_scale) / FP_FromInteger(2)); 
+            field_A8_xpos += field_B4_velx + (ScaleToGridSize_41FA30(field_BC_sprite_scale) / FP_FromInteger(2));
         }
         else
         {
@@ -1701,7 +1701,7 @@ void Slog::State_19_JumpForwards_475610()
 
     const FP oldXPos = field_A8_xpos;
     const FP ypos1 = field_AC_ypos - (field_BC_sprite_scale * FP_FromInteger(20));
-    
+
     field_A8_xpos += field_B4_velx;
     field_AC_ypos += field_B8_vely;
 
@@ -1908,7 +1908,7 @@ void Slog::State_24_Growl_475590()
 
 const __int16 sSlogResponseMotion_4CFCF0[3][10] =
 {
-    { 
+    {
         eSlogStates::State_3_TurnAround_474C70,
         eSlogStates::State_2_Run_4749A0,
         eSlogStates::State_8_StopRunning_474EC0,
@@ -2136,7 +2136,7 @@ __int16 Slog::Brain_0_ListeningToSlig_472450()
         {
             field_150_waiting_counter++;
         }
-        // Fall through
+        [[fallthrough]];
     case GameSpeakEvents::Slig_HereBoy_24:
         field_150_waiting_counter++;
         field_11C_timer = gnFrameCount_507670 - (Math_NextRandom() % 8) + 15;
@@ -2524,7 +2524,7 @@ __int16 Slog::Brain_2_ChasingAbe_470F50()
         field_114_brain_idx = 0;
         field_14C_pSlig = sControlledCharacter_50767C;
         field_14C_pSlig->field_C_refCount++;
-      
+
         if (field_10C_pTarget)
         {
             field_10C_pTarget->field_C_refCount--;

--- a/Source/AliveLibAO/TrapDoor.cpp
+++ b/Source/AliveLibAO/TrapDoor.cpp
@@ -291,7 +291,7 @@ void TrapDoor::VUpdate_4883E0()
 
     case 2:
         field_130_stay_open_time--;
-        if (field_13C_set_switch_on_dead && !field_130_stay_open_time ||
+        if ((field_13C_set_switch_on_dead && !field_130_stay_open_time) ||
             SwitchStates_Get(field_134_switch_idx) != SwitchStates_Get(field_138_switch_state))
         {
             const int cur_lvl = static_cast<int>(gMap_507BA8.field_0_current_level);

--- a/Source/AliveLibCommon/Function.hpp
+++ b/Source/AliveLibCommon/Function.hpp
@@ -42,19 +42,20 @@
 #define ALIVE_ARY(Redirect, Addr, TypeName, Size, VarName, ...)\
 TypeName LocalArray_##VarName[Size]=__VA_ARGS__;\
 AliveVar Var_##VarName(#VarName, Addr, sizeof(LocalArray_##VarName), std::is_pointer<TypeName>::value, std::is_const<TypeName>::value);\
-TypeName* VarName = (Redirect && RunningAsInjectedDll()) ? reinterpret_cast<TypeName*>(Addr) : reinterpret_cast<TypeName*>(&LocalArray_##VarName[0]);
+TypeName* VarName = (Redirect && RunningAsInjectedDll()) ? reinterpret_cast<TypeName*>(Addr) : reinterpret_cast<TypeName*>(&LocalArray_##VarName[0])
+
 #define ALIVE_ARY_SIZEOF(VarName) sizeof(LocalArray_##VarName)
 
 // Only use this for pointers to arrays until it can be changed to ALIVE_ARY (so this is only used when the array size is not yet known)
 #define ALIVE_PTR(Redirect, Addr, TypeName, VarName, Value)\
 TypeName LocalPtr_##VarName = Value;\
 AliveVar Var_##VarName(#VarName, Addr, sizeof(LocalPtr_##VarName), std::is_pointer<TypeName>::value, std::is_const<TypeName>::value);\
-std::remove_pointer<TypeName>::type * VarName = (Redirect && RunningAsInjectedDll()) ? reinterpret_cast<TypeName>(Addr) : LocalPtr_##VarName;
+std::remove_pointer<TypeName>::type * VarName = (Redirect && RunningAsInjectedDll()) ? reinterpret_cast<TypeName>(Addr) : LocalPtr_##VarName
 
 #define ALIVE_VAR(Redirect, Addr, TypeName, VarName, Value)\
 TypeName LocalVar_##VarName = Value;\
 AliveVar Var_##VarName(#VarName, Addr, sizeof(LocalVar_##VarName), std::is_pointer<TypeName>::value, std::is_const<TypeName>::value);\
-TypeName& VarName = (Redirect && RunningAsInjectedDll()) ? *reinterpret_cast<TypeName*>(Addr) : LocalVar_##VarName;
+TypeName& VarName = (Redirect && RunningAsInjectedDll()) ? *reinterpret_cast<TypeName*>(Addr) : LocalVar_##VarName
 
 
 void CheckVars();

--- a/Source/AliveLibCommon/FunctionFwd.hpp
+++ b/Source/AliveLibCommon/FunctionFwd.hpp
@@ -7,7 +7,7 @@ bool RunningAsInjectedDll();
 #define CC __cdecl
 #define CCSTD __stdcall
 #if _WIN64
-#define ALIVE_ASSERT_SIZEOF(structureName, expectedSize)
+#define ALIVE_ASSERT_SIZEOF(structureName, expectedSize) static_assert(true)
 #else
 #define ALIVE_ASSERT_SIZEOF(structureName, expectedSize) static_assert(sizeof(structureName) == expectedSize, "sizeof(" #structureName ") must be " #expectedSize)
 #endif
@@ -15,7 +15,7 @@ bool RunningAsInjectedDll();
 #define EXPORT
 #define CC
 #define CCSTD
-#define ALIVE_ASSERT_SIZEOF(structureName, expectedSize)
+#define ALIVE_ASSERT_SIZEOF(structureName, expectedSize) static_assert(true)
 
 // Replace with a function that actually exists but does the same thing
 #define strcmpi strcasecmp
@@ -46,8 +46,8 @@ public:
 
 #define ALIVE_VAR_EXTERN(TypeName, VarName)\
 extern TypeName LocalVar_##VarName;\
-extern TypeName& VarName;
+extern TypeName& VarName
 
 #define ALIVE_ARY_EXTERN(TypeName, Size, VarName)\
 extern AliveVar Var_##VarName;\
-extern TypeName* VarName ;
+extern TypeName* VarName


### PR DESCRIPTION
- Swallow semicolons in macros to avoid "extra semicolon" warnings
- Wrap pieces of long logical expressions in parentheses to avoid "logical-op" warnings, making precedence obvious
- Use `[[fallthrough]]` attribute

None of these changes should have any effect on the behavior of the project whatsoever. 