### PR TITLE
Remove busy loops

### DIFF
--- a/Source/AliveLibAE/Sound/PsxSpuApi.hpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.hpp
@@ -3,6 +3,7 @@
 #include "../AliveLibCommon/FunctionFwd.hpp"
 #include "Sound/Sound.hpp"
 #include "Io.hpp"
+#include "Sys_common.hpp"
 
 struct ProgAtr final
 {
@@ -238,6 +239,12 @@ using TVSyncCallBackFn = void(CC*)();
 EXPORT void CC VSyncCallback_4F8C40(TVSyncCallBackFn callBack);
 EXPORT void CC SND_CallBack_4020A4(); // TODO: Naming??
 EXPORT void CC SsSeqCalledTbyT_4FDC80();
+
+// returns 
+//    true, after having slept for the correct duration, if SsSeqCalledTbyT_4FDC80 must be called
+//    false if time to wait would have gone over max_time
+// Note that this does *not* call SsSeqCalledTbyT_4FDC80
+EXPORT bool CC SsSeqCalledTbyT_4FDC80_sleep_until_due_time_if_before_max_time(SYS_time_point_t current_time, SYS_time_point_t max_time);
 
 // Most likely PC specific extensions that have been inlined
 void SsExt_CloseAllVabs();

--- a/Source/AliveLibAE/Sound/SDLSoundSystem.hpp
+++ b/Source/AliveLibAE/Sound/SDLSoundSystem.hpp
@@ -3,6 +3,8 @@
 #include "Sound.hpp"
 #include "SoundSDL.hpp"
 #include <thread>
+#include <condition_variable>
+#include <mutex>
 
 #define CI_DISABLE_ASSERTS
 #include <cinder/audio/dsp/RingBuffer.h>
@@ -53,6 +55,11 @@ private:
     std::vector<StereoSample_S16> mTempSoundBuffer;
     std::vector<StereoSample_S16> mNoReverbBuffer;
     cinder::audio::dsp::RingBufferT<StereoSample_S16> mAudioRingBuffer;
+
+    // to avoid busy loop
+    std::mutex mAudioRingBufferMutex;
+    std::condition_variable mAudioRingBufferConditionVariable;
+
     std::atomic_bool mRenderAudioThreadQuit{false};
     std::unique_ptr<std::thread> mRenderAudioThread;
 

--- a/Source/AliveLibAO/Movie.cpp
+++ b/Source/AliveLibAO/Movie.cpp
@@ -444,7 +444,7 @@ void Movie::VUpdate_489EA0()
     Bitmap tmpBmp = {};
 
     // Till EOF decoding loop
-    const auto movieStartTimeStamp = SYS_GetTicks();
+    const auto movieStartTimeStamp = SYS_GetTime();
     while (psxStr.DecodeAudioAndVideo())
     {
         fmv_num_read_frames++;
@@ -492,11 +492,12 @@ void Movie::VUpdate_489EA0()
 
         Render_Str_Frame(tmpBmp);
 
-        const int maxAudioSyncTimeWait = 1000 * fmv_num_read_frames / kFmvFrameRate - 200;
-
-        while ((signed int) (SYS_GetTicks() - movieStartTimeStamp) <= maxAudioSyncTimeWait)
+        const auto maxAudioSyncTimeWait = std::chrono::milliseconds{1000 * fmv_num_read_frames / kFmvFrameRate - 200};
+        const auto timeToWait = maxAudioSyncTimeWait - (SYS_GetTime() - movieStartTimeStamp);
+        if (timeToWait.count() > 0)
         {
             // Wait for the amount of time the frame would take to display at the given framerate
+            std::this_thread::sleep_for(timeToWait);
         }
 
         SYS_EventsPump_44FF90();

--- a/Source/AliveLibCommon/Sys_common.cpp
+++ b/Source/AliveLibCommon/Sys_common.cpp
@@ -13,16 +13,19 @@
     abort();
 }
 
+SYS_time_point_t SYS_GetTime()
+{
+    return std::chrono::steady_clock::now();
+}
+
+u32 SYS_AsU32Ms(SYS_time_point_t t)
+{
+    return (u32) std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch()).count();
+}
 
 u32 SYS_GetTicks()
 {
-#if USE_SDL2
-    // Using this instead of SDL_GetTicks resolves a weird x64 issue on windows where
-    // the tick returned is a lot faster on some machines.
-    return static_cast<u32>(SDL_GetPerformanceCounter() / (SDL_GetPerformanceFrequency() / 1000));
-#else
-    return timeGetTime();
-#endif
+    return SYS_AsU32Ms(SYS_GetTime());
 }
 
 MessageBoxButton CC Sys_MessageBox(TWindowHandleType windowHandle, const char_type* message, const char_type* title, MessageBoxType type)

--- a/Source/AliveLibCommon/Sys_common.hpp
+++ b/Source/AliveLibCommon/Sys_common.hpp
@@ -2,6 +2,7 @@
 
 #include "../AliveLibCommon/FunctionFwd.hpp"
 #include "relive_config.h"
+#include <chrono>
 
 #if _WIN32
 using TWindowProcFilter = LRESULT(CC*)(HWND, UINT, WPARAM, LPARAM);
@@ -77,4 +78,7 @@ inline void Alive_Show_ErrorMsg(const char_type* msg)
 
 [[noreturn]] void ALIVE_FATAL(const char_type* errMsg);
 
+using SYS_time_point_t = std::chrono::steady_clock::time_point;
+SYS_time_point_t SYS_GetTime();
+u32 SYS_AsU32Ms(SYS_time_point_t);
 u32 SYS_GetTicks();


### PR DESCRIPTION
replaced with either
    this_thread::sleep_*
    condition_variable for audio read/write loop

this reduces usage from "around 16%" (on a recent 16t CPU, thus a 2.5 threads load)
to a nicer "around 0.7%"