### PR TITLE
Demo order fix.

### DIFF
--- a/Source/AliveLibAE/MainMenu.cpp
+++ b/Source/AliveLibAE/MainMenu.cpp
@@ -2207,6 +2207,14 @@ MainMenuNextCam MainMenuController::LoadDemo_Update_4D1040(u32)
         }
         field_6_flags.Set(Options::eDead_Bit3);
 
+
+        char_type file[32] = {};
+        sprintf(file, "ATTR%04d.SAV", sDemos_5617F0[demoId].field_A_id);
+        ResourceManager::LoadResourceFile_49C170(file, nullptr);
+        u8** resource = ResourceManager::GetLoadedResource_49C2A0(ResourceManager::ResourceType::Resource_NxtP, ResourceID::kUnknownResID_0, 1, 0);
+        sActiveQuicksaveData_BAF7F8 = *(reinterpret_cast<Quicksave*>(*resource));
+        ResourceManager::FreeResource_49C330(resource);
+
         demoId = sDemoIdChosenFromDemoMenu_5C1B9E;
         if (!gIsDemoStartedManually_5C1B9C)
         {
@@ -2219,13 +2227,6 @@ MainMenuNextCam MainMenuController::LoadDemo_Update_4D1040(u32)
             }
             demoId = sCurrentDemoIdForIdlingDemoPlayback_5C1BA2;
         }
-
-        char_type file[32] = {};
-        sprintf(file, "ATTR%04d.SAV", sDemos_5617F0[demoId].field_A_id);
-        ResourceManager::LoadResourceFile_49C170(file, nullptr);
-        u8** resource = ResourceManager::GetLoadedResource_49C2A0(ResourceManager::ResourceType::Resource_NxtP, ResourceID::kUnknownResID_0, 1, 0);
-        sActiveQuicksaveData_BAF7F8 = *(reinterpret_cast<Quicksave*>(*resource));
-        ResourceManager::FreeResource_49C330(resource);
 
         if (gIsDemoStartedManually_5C1B9C)
         {

--- a/Source/AliveLibAE/MainMenu.cpp
+++ b/Source/AliveLibAE/MainMenu.cpp
@@ -2207,7 +2207,6 @@ MainMenuNextCam MainMenuController::LoadDemo_Update_4D1040(u32)
         }
         field_6_flags.Set(Options::eDead_Bit3);
 
-
         char_type file[32] = {};
         sprintf(file, "ATTR%04d.SAV", sDemos_5617F0[demoId].field_A_id);
         ResourceManager::LoadResourceFile_49C170(file, nullptr);

--- a/Source/AliveLibAE/MainMenu.cpp
+++ b/Source/AliveLibAE/MainMenu.cpp
@@ -2214,7 +2214,6 @@ MainMenuNextCam MainMenuController::LoadDemo_Update_4D1040(u32)
         sActiveQuicksaveData_BAF7F8 = *(reinterpret_cast<Quicksave*>(*resource));
         ResourceManager::FreeResource_49C330(resource);
 
-        demoId = sDemoIdChosenFromDemoMenu_5C1B9E;
         if (!gIsDemoStartedManually_5C1B9C)
         {
             sCurrentDemoIdForIdlingDemoPlayback_5C1BA2++;
@@ -2224,7 +2223,6 @@ MainMenuNextCam MainMenuController::LoadDemo_Update_4D1040(u32)
                 // all the "idling" demos have been played, wrap around
                 sCurrentDemoIdForIdlingDemoPlayback_5C1BA2 = 1;
             }
-            demoId = sCurrentDemoIdForIdlingDemoPlayback_5C1BA2;
         }
 
         if (gIsDemoStartedManually_5C1B9C)


### PR DESCRIPTION
The variable responsible for storing ID of the currently playing demo was incremented too quickly, therefore the first demo  was skipped when shouldn't.

Issue was only present in RELIVE