### PR TITLE
Audio panning

### DIFF
--- a/Source/AliveLibAE/Abe.cpp
+++ b/Source/AliveLibAE/Abe.cpp
@@ -587,7 +587,7 @@ EXPORT s32 CC Environment_SFX_457A40(EnvironmentSfx sfxId, s32 volume, s32 pitch
                     static_cast<s16>(2 * sndVolume / 9),
                     static_cast<s16>(2 * sndVolume / 9),
                     static_cast<s16>(pitchMin),
-                    0x7FFF);
+                    0x7FFF, 64);
                 break;
             case CameraPos::eCamRight_4:
                 return SFX_SfxDefinition_Play_4CA700(
@@ -595,7 +595,7 @@ EXPORT s32 CC Environment_SFX_457A40(EnvironmentSfx sfxId, s32 volume, s32 pitch
                     static_cast<s16>(2 * sndVolume / 3),
                     static_cast<s16>(2 * sndVolume / 3),
                     static_cast<s16>(pitchMin),
-                    0x7FFF);
+                    0x7FFF, 64);
                 break;
             default:
                 return 0;
@@ -10019,7 +10019,7 @@ EXPORT void CC Mudokon_SFX_457EC0(MudSounds idx, s16 volume, s32 pitch, BaseAliv
                         &sAbeSFXList_555250[idxToVal],
                         2 * volume / 3,
                         2 * volume / 9,
-                        static_cast<s16>(pitch), static_cast<s16>(pitch));
+                        static_cast<s16>(pitch), static_cast<s16>(pitch), 64);
                     break;
                 }
                 case CameraPos::eCamRight_4:
@@ -10028,7 +10028,7 @@ EXPORT void CC Mudokon_SFX_457EC0(MudSounds idx, s16 volume, s32 pitch, BaseAliv
                         &sAbeSFXList_555250[idxToVal],
                         2 * volume / 9,
                         2 * volume / 3,
-                        static_cast<s16>(pitch), static_cast<s16>(pitch));
+                        static_cast<s16>(pitch), static_cast<s16>(pitch), 64);
                     break;
                 }
                 default:

--- a/Source/AliveLibAE/Fleech.cpp
+++ b/Source/AliveLibAE/Fleech.cpp
@@ -2123,7 +2123,7 @@ s32 Fleech::Sound_430520(FleechSound soundId)
         volumeLeft,
         volumeRight,
         effectDef.field_4_pitch_min,
-        effectDef.field_6_pitch_max);
+        effectDef.field_6_pitch_max, 64);
 }
 
 u8** Fleech::ResBlockForMotion_42A530(s32 /*motion*/)

--- a/Source/AliveLibAE/Glukkon.cpp
+++ b/Source/AliveLibAE/Glukkon.cpp
@@ -2859,7 +2859,7 @@ void CC Glukkon::PlaySound_4447D0(s32 sndIdx, Glukkon* pGlukkon)
         volumeRight = FP_GetExponent(FP_FromInteger(volumeRight * 2) / FP_FromInteger(3));
     }
 
-    SFX_SfxDefinition_Play_4CA700(&stepSfx_554840[sndIdx], (s16) volumeLeft, (s16) volumeRight, pitch, pitch);
+    SFX_SfxDefinition_Play_4CA700(&stepSfx_554840[sndIdx], (s16) volumeLeft, (s16) volumeRight, pitch, pitch, 64);
 }
 
 void Glukkon::ToDead_43F640()

--- a/Source/AliveLibAE/MainMenu.cpp
+++ b/Source/AliveLibAE/MainMenu.cpp
@@ -3692,7 +3692,7 @@ void MainMenuController::AnimationAndSoundLogic_4CFE80()
             {
                 if (field_220_frame_table_idx == eParamite_AllAYa)
                 {
-                    SFX_SfxDefinition_Play_4CA700(&mainMenu_stru_55D7C0[sMainMenuFrameTable_561CC8[field_220_frame_table_idx].field_6_sound], 127, 127, 64, 64);
+                    SFX_SfxDefinition_Play_4CA700(&mainMenu_stru_55D7C0[sMainMenuFrameTable_561CC8[field_220_frame_table_idx].field_6_sound], 127, 127, 64, 64, 64);
                 }
                 // Attack
                 else if (sMainMenuFrameTable_561CC8[field_220_frame_table_idx].field_6_sound == 9)
@@ -3702,7 +3702,7 @@ void MainMenuController::AnimationAndSoundLogic_4CFE80()
                 // All other Paramite speak
                 else
                 {
-                    SFX_SfxDefinition_Play_4CA700(&mainMenu_stru_55D7C0[sMainMenuFrameTable_561CC8[field_220_frame_table_idx].field_6_sound], 127, 127, 0x7FFF, 0x7FFF);
+                    SFX_SfxDefinition_Play_4CA700(&mainMenu_stru_55D7C0[sMainMenuFrameTable_561CC8[field_220_frame_table_idx].field_6_sound], 127, 127, 0x7FFF, 0x7FFF, 64);
                 }
             }
         }
@@ -3757,7 +3757,7 @@ void MainMenuController::AnimationAndSoundLogic_4CFE80()
                                     mainMenu_sScrabSfx_560330[sound].field_3_default_volume,
                                     mainMenu_sScrabSfx_560330[sound].field_3_default_volume,
                                     0x7FFF,
-                                    0x7FFF);
+                                    0x7FFF, 64);
                                 field_23C_T80.Set(Flags::eBit22_GameSpeakPlaying);
                                 break;
 

--- a/Source/AliveLibAE/Movie.cpp
+++ b/Source/AliveLibAE/Movie.cpp
@@ -140,7 +140,7 @@ EXPORT s8 CC DDV_StartAudio_493DF0()
         if (!bNoAudioOrAudioError_5CA1F4)
         {
             // Sound entry is created and populated with 1 frame, play it
-            if (FAILED(GetSoundAPI().SND_PlayEx(&fmv_sound_entry_5CA208, 116, 116, 1.0, 0, 1, 100)))
+            if (FAILED(GetSoundAPI().SND_PlayEx(&fmv_sound_entry_5CA208, 116, 116, 1.0, 0, 1, 100, 0)))
             {
                 bNoAudioOrAudioError_5CA1F4 = 1;
             }

--- a/Source/AliveLibAE/Paramite.cpp
+++ b/Source/AliveLibAE/Paramite.cpp
@@ -6306,11 +6306,11 @@ void Paramite::Sound_48F600(ParamiteSpeak soundId, s16 pitch_min)
     }
     else if (pitch_min > 0)
     {
-        SFX_SfxDefinition_Play_4CA700(&paramite_stru_55D7C0[static_cast<s32>(soundId)], volLeft, volRight, pitch_min, pitch_min);
+        SFX_SfxDefinition_Play_4CA700(&paramite_stru_55D7C0[static_cast<s32>(soundId)], volLeft, volRight, pitch_min, pitch_min, 64);
     }
     else
     {
-        SFX_SfxDefinition_Play_4CA700(&paramite_stru_55D7C0[static_cast<s32>(soundId)], volLeft, volRight, -520, -520);
+        SFX_SfxDefinition_Play_4CA700(&paramite_stru_55D7C0[static_cast<s32>(soundId)], volLeft, volRight, -520, -520, 64);
     }
 }
 

--- a/Source/AliveLibAE/Scrab.cpp
+++ b/Source/AliveLibAE/Scrab.cpp
@@ -4024,7 +4024,7 @@ s32 Scrab::Scrab_SFX_4AADB0(ScrabSounds soundId, s32 vol, s32 pitch, s16 applyDi
         volumeLeft,
         volumeRight,
         static_cast<s16>(pitch),
-        static_cast<s16>(pitch));
+        static_cast<s16>(pitch), 64);
 }
 
 void Scrab::KillTarget_4A7F20(BaseAliveGameObject* pTarget)

--- a/Source/AliveLibAE/Sfx.hpp
+++ b/Source/AliveLibAE/Sfx.hpp
@@ -171,4 +171,4 @@ enum class SligSpeak : s8
 };
 
 EXPORT void CC Slig_GameSpeak_SFX_4C04F0(SligSpeak effectId, s16 defaultVol, s16 pitch_min, BaseAnimatedWithPhysicsGameObject* pObj);
-EXPORT s16 CC Calc_Slig_Sound_Direction_4C01B0(BaseAnimatedWithPhysicsGameObject* pObj, s16 defaultVol, const SfxDefinition* pSfx, s16* pLeftVol, s16* pRightVol);
+EXPORT s16 CC Calc_Slig_Sound_Direction_4C01B0(BaseAnimatedWithPhysicsGameObject* pObj, s16 defaultVol, const SfxDefinition* pSfx, s16* pLeftVol, s16* pRightVol, s32* pan);

--- a/Source/AliveLibAE/Slig.cpp
+++ b/Source/AliveLibAE/Slig.cpp
@@ -59,7 +59,8 @@ void CC Slig_SoundEffect_4BFFE0(SligSfx effect, BaseAliveGameObject* pObj)
     const SfxDefinition* pEffect = &kSfxInfoTable_5607E0[static_cast<s32>(effect)];
     s16 vLeft = 0;
     s16 vRight = 0;
-    if (Calc_Slig_Sound_Direction_4C01B0(pObj, 0, pEffect, &vLeft, &vRight))
+    s32 pan = 64;
+    if (Calc_Slig_Sound_Direction_4C01B0(pObj, 0, pEffect, &vLeft, &vRight, &pan))
     {
         s16 pitch = 0;
         if (effect == SligSfx::ePropeller1_9 || effect == SligSfx::ePropeller2_10 || effect == SligSfx::ePropeller3_11)
@@ -76,7 +77,7 @@ void CC Slig_SoundEffect_4BFFE0(SligSfx effect, BaseAliveGameObject* pObj)
         {
             pitch = Math_RandomRange_496AB0(pEffect->field_4_pitch_min, pEffect->field_6_pitch_max);
         }
-        SFX_SfxDefinition_Play_4CA700(pEffect, vLeft, vRight, pitch, pitch);
+        SFX_SfxDefinition_Play_4CA700(pEffect, vLeft, vRight, pitch, pitch, pan);
     }
 }
 

--- a/Source/AliveLibAE/Slog.cpp
+++ b/Source/AliveLibAE/Slog.cpp
@@ -3091,7 +3091,7 @@ void Slog::Sfx_4C7D30(SlogSound effectId)
             volumeLeft,
             volumeRight,
             effectDef.field_4_pitch_min + 1524,
-            effectDef.field_6_pitch_max + 1524);
+            effectDef.field_6_pitch_max + 1524 , 64);
     }
     else
     {
@@ -3100,7 +3100,7 @@ void Slog::Sfx_4C7D30(SlogSound effectId)
             volumeLeft,
             volumeRight,
             effectDef.field_4_pitch_min,
-            effectDef.field_6_pitch_max);
+            effectDef.field_6_pitch_max, 64);
     }
 }
 

--- a/Source/AliveLibAE/Sound/Midi.cpp
+++ b/Source/AliveLibAE/Sound/Midi.cpp
@@ -263,10 +263,10 @@ EXPORT s16 CC SND_VAB_Load_4C9FE0(SoundBlockInfo* pSoundBlockInfo, s16 vabId)
 
 // TODO: PSX has VSyncCallback here 0x800592dc
 
-EXPORT s32 CC MIDI_Play_Single_Note_4CA1B0(s32 vabIdAndProgram, s32 note, s32 leftVol, s32 rightVol)
+EXPORT s32 CC MIDI_Play_Single_Note_4CA1B0(s32 vabIdAndProgram, s32 note, s32 leftVol, s32 rightVol, s32 pan)
 {
     // NOTE: word_BB2E40 is used as a guard here, but it is never read anywhere else
-    return SsVoKeyOn_4FCF10(vabIdAndProgram, note, static_cast<u16>(leftVol), static_cast<u16>(rightVol));
+    return SsVoKeyOn_4FCF10(vabIdAndProgram, note, static_cast<u16>(leftVol), static_cast<u16>(rightVol), pan);
 }
 
 EXPORT void CC SND_Init_4CA1F0()
@@ -383,7 +383,8 @@ s32 CC SFX_SfxDefinition_Play_4CA420(const SfxDefinition* sfxDef, s16 volume, s1
         sfxDef->field_1_program | (GetMidiVars()->sLastLoadedSoundBlockInfo()[sfxDef->field_0_block_idx].field_8_vab_id << 8),
         sfxDef->field_2_note << 8,
         volume,
-        volume);
+        volume,
+        64);
 
     if (!GetMidiVars()->sSFXPitchVariationEnabled())
     {
@@ -444,7 +445,7 @@ EXPORT s32 CC SND_4CA5D0(s32 program, s32 vabId, s32 note, s16 vol, s16 min, s16
     }
 
     // Note: Inlined in psx
-    const s32 channelBits = MIDI_Play_Single_Note_4CA1B0(vabId | ((s16) program << 8), note << 8, volClamped, volClamped);
+    const s32 channelBits = MIDI_Play_Single_Note_4CA1B0(vabId | ((s16) program << 8), note << 8, volClamped, volClamped, 64);
     if (!GetMidiVars()->sSFXPitchVariationEnabled())
     {
         return 0;
@@ -478,7 +479,7 @@ EXPORT s32 CC SND_4CA5D0(s32 program, s32 vabId, s32 note, s16 vol, s16 min, s16
     return channelBits;
 }
 
-s32 CC SFX_SfxDefinition_Play_4CA700(const SfxDefinition* sfxDef, s16 volLeft, s16 volRight, s16 pitch_min, s16 pitch_max)
+s32 CC SFX_SfxDefinition_Play_4CA700(const SfxDefinition* sfxDef, s16 volLeft, s16 volRight, s16 pitch_min, s16 pitch_max, s32 pan)
 {
     if (pitch_min == 0x7FFF)
     {
@@ -513,7 +514,8 @@ s32 CC SFX_SfxDefinition_Play_4CA700(const SfxDefinition* sfxDef, s16 volLeft, s
         sfxDef->field_1_program | (GetMidiVars()->sLastLoadedSoundBlockInfo()[sfxDef->field_0_block_idx].field_8_vab_id << 8),
         sfxDef->field_2_note << 8,
         volLeft,
-        volRight);
+        volRight,
+        pan);
 
     if (!GetMidiVars()->sSFXPitchVariationEnabled())
     {

--- a/Source/AliveLibAE/Sound/Midi.hpp
+++ b/Source/AliveLibAE/Sound/Midi.hpp
@@ -72,7 +72,7 @@ EXPORT s16 CC SND_SEQ_PlaySeq_4CA960(u16 idx, s16 repeatCount, s16 bDontStop);
 EXPORT void CC SND_SEQ_SetVol_4CAD20(s32 idx, s16 volLeft, s16 volRight);
 EXPORT s16 CC SND_SEQ_Play_4CAB10(u16 idx, s16 repeatCount, s16 volLeft, s16 volRight);
 EXPORT s32 CC SND_SsIsEos_DeInlined_4CACD0(u16 idx);
-EXPORT s32 CC SFX_SfxDefinition_Play_4CA700(const SfxDefinition* sfxDef, s16 volLeft, s16 volRight, s16 pitch_min, s16 pitch_max);
+EXPORT s32 CC SFX_SfxDefinition_Play_4CA700(const SfxDefinition* sfxDef, s16 volLeft, s16 volRight, s16 pitch_min, s16 pitch_max, s32 pan);
 EXPORT s32 CC SFX_SfxDefinition_Play_4CA420(const SfxDefinition* sfxDef, s16 volume, s16 pitch_min, s16 pitch_max);
 
 enum SeqId

--- a/Source/AliveLibAE/Sound/PsxSpuApi.cpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.cpp
@@ -689,8 +689,6 @@ EXPORT s32 CC MIDI_PlayMidiNote_4FCB30(s32 vabId, s32 program, s32 note, s32 lef
 
                     // Pan - L=0, C=64, R=127
                     s8 pan = pVagIter->field_11_pad;
-                    panLeft = pVagIter->field_D_vol;
-                    panRight = pVagIter->field_D_vol;
                     if (pan == 127)
                     {
                         panLeft = 0;

--- a/Source/AliveLibAE/Sound/PsxSpuApi.cpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.cpp
@@ -687,6 +687,19 @@ EXPORT s32 CC MIDI_PlayMidiNote_4FCB30(s32 vabId, s32 program, s32 note, s32 lef
                         MIDI_Wait_4FCE50();
                     }
 
+                    // Pan - L=0, C=64, R=127
+                    s8 pan = pVagIter->field_11_pad;
+                    panLeft = pVagIter->field_D_vol;
+                    panRight = pVagIter->field_D_vol;
+                    if (pan == 127)
+                    {
+                        panLeft = 0;
+                    }
+                    else if (pan == 0)
+                    {
+                        panRight = 0;
+                    }
+
                     GetSoundAPI().SND_PlayEx(
                         &gSpuVars->sSoundEntryTable16().table[vabId][pVagIter->field_10_vag],
                         panLeft,
@@ -1355,10 +1368,15 @@ EXPORT void CC SsSeqCalledTbyT_4FDC80()
     {
         const u32 currentTime = SYS_GetTicks();
         gSpuVars->sMidiTime() = currentTime;
-        // First time or 30 passed?
-        if (gSpuVars->sLastTime() == 0xFFFFFFFF || (s32)(currentTime - gSpuVars->sLastTime()) >= 30)
-        {
-            gSpuVars->sLastTime() = currentTime;
+
+        // This seems to be limiting the rate of playback,
+        // maybe to save some CPU cycles? Removing helps
+        // audio playback stay in time
+        // 
+        //// First time or 30 passed?
+        //if (gSpuVars->sLastTime() == 0xFFFFFFFF || (s32)(currentTime - gSpuVars->sLastTime()) >= 30)
+        //{
+        //    gSpuVars->sLastTime() = currentTime;
             for (s32 i = 0; i < kNumChannels; i++)
             {
                 if (gSpuVars->sMidiSeqSongs(i).field_0_seq_data)
@@ -1370,7 +1388,7 @@ EXPORT void CC SsSeqCalledTbyT_4FDC80()
                 }
             }
             MIDI_ADSR_Update_4FDCE0();
-        }
+        //}
     }
 }
 

--- a/Source/AliveLibAE/Sound/PsxSpuApi.cpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.cpp
@@ -689,13 +689,16 @@ EXPORT s32 CC MIDI_PlayMidiNote_4FCB30(s32 vabId, s32 program, s32 note, s32 lef
 
                     // Pan - L=0, C=64, R=127
                     s32 pan = 0;
-                    if (pVagIter->field_11_pad == 127)
+                    s32 maxPanVal = 9000;
+                    if (pVagIter->field_11_pad < 64)
                     {
-                        pan = 9000;
+                        double val = (pVagIter->field_11_pad / 64.0) * maxPanVal;
+                        pan = ((s32) val) - maxPanVal;
                     }
-                    else if (pVagIter->field_11_pad == 0)
+                    else if (pVagIter->field_11_pad > 64)
                     {
-                        pan = -9000;
+                        double val = ((128 - pVagIter->field_11_pad) / 64.0) * maxPanVal;
+                        pan = maxPanVal - ((s32) val);
                     }
 
                     GetSoundAPI().SND_PlayEx(

--- a/Source/AliveLibAE/Sound/PsxSpuApi.cpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.cpp
@@ -745,14 +745,15 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_4FCE80(s32 vabId, s32 program, s32 note, s
         return 0;
     }
 
-    if (rightVol >= 64)
-    {
-        return MIDI_PlayMidiNote_4FCB30(vabId, program, note, leftVol * (127 - rightVol) / 64, leftVol, volume, 64);
-    }
-    else
-    {
-        return MIDI_PlayMidiNote_4FCB30(vabId, program, note, leftVol, rightVol * leftVol / 64, volume, 64);
-    }
+    return MIDI_PlayMidiNote_4FCB30(vabId, program, note, leftVol, rightVol, volume, 64);
+    //if (rightVol >= 64)
+    //{
+    //    return MIDI_PlayMidiNote_4FCB30(vabId, program, note, leftVol * (127 - rightVol) / 64, leftVol, volume, 64);
+    //}
+    //else
+    //{
+    //    return MIDI_PlayMidiNote_4FCB30(vabId, program, note, leftVol, rightVol * leftVol / 64, volume, 64);
+    //}
 }
 
 
@@ -1021,7 +1022,7 @@ EXPORT s32 CC MIDI_ParseMidiMessage_4FD100(s32 idx)
                         gSpuVars->sMidiSeqSongs(idx2).field_seq_idx,
                         v18->field_0_program,
                         v16 & 0xFF00,
-                        leftVol,
+                        pCtx->field_C_volume,
                         v18->field_2_right_vol,
                         v16 >> 16);
                     channelIdx_1 = 0;

--- a/Source/AliveLibAE/Sound/PsxSpuApi.cpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.cpp
@@ -688,14 +688,14 @@ EXPORT s32 CC MIDI_PlayMidiNote_4FCB30(s32 vabId, s32 program, s32 note, s32 lef
                     }
 
                     // Pan - L=0, C=64, R=127
-                    s8 pan = pVagIter->field_11_pad;
-                    if (pan == 127)
+                    s32 pan = 0;
+                    if (pVagIter->field_11_pad == 127)
                     {
-                        panLeft = 0;
+                        pan = 9000;
                     }
-                    else if (pan == 0)
+                    else if (pVagIter->field_11_pad == 0)
                     {
-                        panRight = 0;
+                        pan = -9000;
                     }
 
                     GetSoundAPI().SND_PlayEx(
@@ -705,7 +705,8 @@ EXPORT s32 CC MIDI_PlayMidiNote_4FCB30(s32 vabId, s32 program, s32 note, s32 lef
                         pChannel->field_10_freq, // freq
                         pChannel,
                         playFlags,
-                        pVagIter->field_E_priority);
+                        pVagIter->field_E_priority,
+                        pan);
 
                     if (program == 4 || program == 5 || program == 8 || program == 23 || program == 24 || program == 25)
                     {

--- a/Source/AliveLibAE/Sound/PsxSpuApi.hpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.hpp
@@ -214,7 +214,7 @@ EXPORT void SsUtReverbOff_4FE350();
 EXPORT void SpuClearReverbWorkArea_4FA690(s32 reverbMode);
 
 EXPORT void CC SsSetTickMode_4FDC20(s32 tickMode);
-EXPORT s32 CC SsVoKeyOn_4FCF10(s32 vabIdAndProgram, s32 pitch, u16 leftVol, u16 rightVol);
+EXPORT s32 CC SsVoKeyOn_4FCF10(s32 vabIdAndProgram, s32 pitch, u16 leftVol, u16 rightVol, s32 pan);
 EXPORT void CC SsUtAllKeyOff_4FDFE0(s32 mode);
 EXPORT s16 CC SsUtKeyOffV_4FE010(s16 idx);
 EXPORT s16 CC SsUtChangePitch_4FDF70(s16 voice, s32 /*vabId*/, s32 /*prog*/, s16 old_note, s16 old_fine, s16 new_note, s16 new_fine);

--- a/Source/AliveLibAE/Sound/Sound.cpp
+++ b/Source/AliveLibAE/Sound/Sound.cpp
@@ -226,7 +226,7 @@ EXPORT s32 CC SND_PlayEx_4EF740(const SoundEntry* pSnd, s32 panLeft, s32 panRigh
     }
 
     pDSoundBuffer->SetFrequency(freqHz);
-    pDSoundBuffer->SetVolume(sVolumeTable_BBBD38[panRightConverted]);
+    pDSoundBuffer->SetVolume(panLeft * 2 > 127 ? 127 : panLeft * 2); // sVolumeTable_BBBD38[panRightConverted]
 
     const s32 panConverted = (DSBPAN_RIGHT * (panLeft2 - panRight)) / 127; // From PSX pan range to DSound pan range
     pDSoundBuffer->SetPan(pan);                                  // Fix Inverted Stereo

--- a/Source/AliveLibAE/Sound/Sound.cpp
+++ b/Source/AliveLibAE/Sound/Sound.cpp
@@ -137,7 +137,7 @@ EXPORT s32 CC SND_Free_4EFA30(SoundEntry* pSnd)
     return 0;
 }
 
-EXPORT s32 CC SND_PlayEx_4EF740(const SoundEntry* pSnd, s32 panLeft, s32 panRight, f32 freq, MIDI_Channel* pMidiStru, s32 playFlags, s32 priority)
+EXPORT s32 CC SND_PlayEx_4EF740(const SoundEntry* pSnd, s32 panLeft, s32 panRight, f32 freq, MIDI_Channel* pMidiStru, s32 playFlags, s32 priority, s32 pan)
 {
     if (!sDSound_BBC344)
     {
@@ -229,7 +229,7 @@ EXPORT s32 CC SND_PlayEx_4EF740(const SoundEntry* pSnd, s32 panLeft, s32 panRigh
     pDSoundBuffer->SetVolume(sVolumeTable_BBBD38[panRightConverted]);
 
     const s32 panConverted = (DSBPAN_RIGHT * (panLeft2 - panRight)) / 127; // From PSX pan range to DSound pan range
-    pDSoundBuffer->SetPan(-panConverted);                                  // Fix Inverted Stereo
+    pDSoundBuffer->SetPan(pan);                                  // Fix Inverted Stereo
 
     if (playFlags & DSBPLAY_LOOPING)
     {

--- a/Source/AliveLibAE/Sound/Sound.cpp
+++ b/Source/AliveLibAE/Sound/Sound.cpp
@@ -226,7 +226,7 @@ EXPORT s32 CC SND_PlayEx_4EF740(const SoundEntry* pSnd, s32 panLeft, s32 panRigh
     }
 
     pDSoundBuffer->SetFrequency(freqHz);
-    pDSoundBuffer->SetVolume(panLeft * 2 > 127 ? 127 : panLeft * 2); // sVolumeTable_BBBD38[panRightConverted]
+    pDSoundBuffer->SetVolume(panLeft > 127 ? 127 : panLeft); // sVolumeTable_BBBD38[panRightConverted]
 
     const s32 panConverted = (DSBPAN_RIGHT * (panLeft2 - panRight)) / 127; // From PSX pan range to DSound pan range
     pDSoundBuffer->SetPan(pan);                                  // Fix Inverted Stereo

--- a/Source/AliveLibAE/Sound/Sound.hpp
+++ b/Source/AliveLibAE/Sound/Sound.hpp
@@ -128,7 +128,7 @@ EXPORT s32 CC SND_LoadSamples_4EF1C0(const SoundEntry* pSnd, u32 sampleOffset, u
 EXPORT u32* CC SND_4F00B0(u32* /*a1*/, u32 /*a2*/, s32 /*a3*/);
 
 struct MIDI_Channel;
-EXPORT s32 CC SND_PlayEx_4EF740(const SoundEntry* pSnd, s32 panLeft, s32 panRight, f32 freq, MIDI_Channel* pMidiStru, s32 playFlags, s32 priority);
+EXPORT s32 CC SND_PlayEx_4EF740(const SoundEntry* pSnd, s32 panLeft, s32 panRight, f32 freq, MIDI_Channel* pMidiStru, s32 playFlags, s32 priority, s32 pan);
 
 struct SoundApi final
 {

--- a/Source/AliveLibAO/Elum.cpp
+++ b/Source/AliveLibAO/Elum.cpp
@@ -934,7 +934,7 @@ void CC Elum::Elum_SFX_416E10(ElumSounds soundId, BaseAliveGameObject* pObj)
                     volRight = 80;
                     break;
             }
-            SFX_SfxDefinition_Play_477330(&sElumSfx_4C5398[3], (s16) volLeft, (s16) volRight, 0, 0);
+            SFX_SfxDefinition_Play_477330(&sElumSfx_4C5398[3], (s16) volLeft, (s16) volRight, 0, 0, 64);
             break;
         }
 

--- a/Source/AliveLibAO/Midi.cpp
+++ b/Source/AliveLibAO/Midi.cpp
@@ -701,10 +701,10 @@ EXPORT s32 CC MIDI_ParseMidiMessage_49DD30(s32 idx)
                         auto r_vol = pProgVol->field_2_right_vol;
                         auto note = data.param1 << 8;
                         auto program = pProgVol->field_0_program;
-                        auto l_vol = (s16)((u32) (pProgVol->field_1_left_vol * pCtx->field_C_volume) >> 7);
+                        // auto l_vol = (s16)((u32) (pProgVol->field_1_left_vol * pCtx->field_C_volume) >> 7);
 
                         auto freq = data.param2;
-                        MIDI_PlayerPlayMidiNote_49DAD0(pCtx->field_seq_idx, program, note, l_vol, r_vol, freq); // Note: inlined
+                        MIDI_PlayerPlayMidiNote_49DAD0(pCtx->field_seq_idx, program, note, pCtx->field_C_volume, r_vol, freq); // Note: inlined
                         break;
                     }
 

--- a/Source/AliveLibAO/Midi.cpp
+++ b/Source/AliveLibAO/Midi.cpp
@@ -508,6 +508,20 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
                         pChannel->field_1C_adsr.field_2_note_byte1 = BYTE1(note) & 0x7F;
                         auto freq = pow(1.059463094359, (f64)(note - v29) * 0.00390625);
                         pChannel->field_10_freq = (f32) freq;
+
+                        // Pan - L=0, C=64, R=127
+                        s8 pan = pVagOff->field_11_pad;
+                        panLeft = pChannel->field_C_vol;
+                        panRight = pChannel->field_C_vol;
+                        if (pan == 127)
+                        {
+                            panLeft = 0;
+                        }
+                        else if (pan == 0)
+                        {
+                            panRight = 0;
+                        }
+
                         SND_PlayEx_493040(
                             &GetSpuApiVars()->sSoundEntryTable16().table[vabId][vag_num],
                             panLeft,
@@ -534,14 +548,17 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
 
 EXPORT s32 CC MIDI_PlayerPlayMidiNote_49DAD0(s32 vabId, s32 program, s32 note, s32 leftVol, s32 rightVol, s32 volume)
 {
-    if (rightVol >= 64)
-    {
-        return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol * (127 - rightVol) / 64, leftVol, volume);
-    }
-    else
-    {
-        return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, leftVol * rightVol / 64, volume);
-    }
+
+    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, rightVol, volume);
+
+    //if (rightVol >= 64)
+    //{
+    //    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol * (127 - rightVol) / 64, leftVol, volume);
+    //}
+    //else
+    //{
+    //    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, leftVol * rightVol / 64, volume);
+    //}
 }
 
 
@@ -676,7 +693,7 @@ EXPORT s32 CC MIDI_ParseMidiMessage_49DD30(s32 idx)
                         auto r_vol = pProgVol->field_2_right_vol;
                         auto note = data.param1 << 8;
                         auto program = pProgVol->field_0_program;
-                        auto l_vol = (s16)((u32)(pProgVol->field_1_left_vol * pCtx->field_C_volume) >> 7);
+                        auto l_vol = pProgVol->field_1_left_vol; // (s16)((u32) (pProgVol->field_1_left_vol * pCtx->field_C_volume) >> 7);
 
                         auto freq = data.param2;
                         MIDI_PlayerPlayMidiNote_49DAD0(pCtx->field_seq_idx, program, note, l_vol, r_vol, freq); // Note: inlined

--- a/Source/AliveLibAO/Midi.cpp
+++ b/Source/AliveLibAO/Midi.cpp
@@ -507,6 +507,14 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
                         auto v29 = pVagOff->field_A_shift_cen;
                         pChannel->field_1C_adsr.field_2_note_byte1 = BYTE1(note) & 0x7F;
                         auto freq = pow(1.059463094359, (f64)(note - v29) * 0.00390625);
+
+                        // Example for fixing the chirp sound in AO
+                        // Maybe create a map that can contain fixes for specific ids
+                        if (pVagOff->field_10_vag == 0)
+                        {
+                            freq = 0.5;
+                        }
+
                         pChannel->field_10_freq = (f32) freq;
 
                         // Pan - L=0, C=64, R=127
@@ -550,14 +558,15 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
 
 EXPORT s32 CC MIDI_PlayerPlayMidiNote_49DAD0(s32 vabId, s32 program, s32 note, s32 leftVol, s32 rightVol, s32 volume)
 {
-    if (rightVol >= 64)
-    {
-        return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol * (127 - rightVol) / 64, leftVol, volume);
-    }
-    else
-    {
-        return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, leftVol * rightVol / 64, volume);
-    }
+    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, rightVol, volume);
+    //if (rightVol >= 64)
+    //{
+    //    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol * (127 - rightVol) / 64, leftVol, volume);
+    //}
+    //else
+    //{
+    //    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, leftVol * rightVol / 64, volume);
+    //}
 }
 
 
@@ -1099,10 +1108,10 @@ static ::SfxDefinition ToAeSfxDef(const SfxDefinition* sfxDef)
     return aeDef;
 }
 
-EXPORT s32 CC SFX_SfxDefinition_Play_477330(const SfxDefinition* sfxDef, s16 volLeft, s16 volRight, s16 pitch_min, s16 pitch_max)
+EXPORT s32 CC SFX_SfxDefinition_Play_477330(const SfxDefinition* sfxDef, s16 volLeft, s16 volRight, s16 pitch_min, s16 pitch_max, s32 pan)
 {
     const ::SfxDefinition aeDef = ToAeSfxDef(sfxDef);
-    return SFX_SfxDefinition_Play_4CA700(&aeDef, volLeft, volRight, pitch_min, pitch_max);
+    return SFX_SfxDefinition_Play_4CA700(&aeDef, volLeft, volRight, pitch_min, pitch_max, pan);
 }
 
 EXPORT s32 CC SFX_SfxDefinition_Play_4770F0(const SfxDefinition* sfxDef, s32 vol, s32 pitch_min, s32 pitch_max)

--- a/Source/AliveLibAO/Midi.cpp
+++ b/Source/AliveLibAO/Midi.cpp
@@ -511,8 +511,6 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
 
                         // Pan - L=0, C=64, R=127
                         s8 pan = pVagOff->field_11_pad;
-                        panLeft = pChannel->field_C_vol;
-                        panRight = pChannel->field_C_vol;
                         if (pan == 127)
                         {
                             panLeft = 0;

--- a/Source/AliveLibAO/Midi.cpp
+++ b/Source/AliveLibAO/Midi.cpp
@@ -320,9 +320,9 @@ EXPORT s16 CC SND_SsIsEos_DeInlined_477930(SeqId idx)
     return static_cast<s16>(SND_SsIsEos_DeInlined_4CACD0(static_cast<u16>(idx)));
 }
 
-EXPORT s32 CC SND_PlayEx_493040(const SoundEntry* pSnd, s32 panLeft, s32 panRight, f32 freq, MIDI_Channel* pMidiStru, s32 playFlags, s32 priority)
+EXPORT s32 CC SND_PlayEx_493040(const SoundEntry* pSnd, s32 panLeft, s32 panRight, f32 freq, MIDI_Channel* pMidiStru, s32 playFlags, s32 priority, s32 pan)
 {
-    return SND_PlayEx_4EF740(pSnd, panLeft, panRight, freq, pMidiStru, playFlags, priority);
+    return SND_PlayEx_4EF740(pSnd, panLeft, panRight, freq, pMidiStru, playFlags, priority, pan);
 }
 
 EXPORT s32 CC SND_Get_Buffer_Status_491D40(s32 idx)
@@ -510,14 +510,14 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
                         pChannel->field_10_freq = (f32) freq;
 
                         // Pan - L=0, C=64, R=127
-                        s8 pan = pVagOff->field_11_pad;
-                        if (pan == 127)
+                        s32 pan = 0;
+                        if (pVagOff->field_11_pad == 127)
                         {
-                            panLeft = 0;
+                            pan = 9000;
                         }
-                        else if (pan == 0)
+                        else if (pVagOff->field_11_pad == 0)
                         {
-                            panRight = 0;
+                            pan = -9000;
                         }
 
                         SND_PlayEx_493040(
@@ -527,7 +527,8 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
                             (f32) freq,
                             pChannel,
                             playFlags,
-                            priority_);
+                            priority_,
+                            pan);
                         volume_ = volume;
                         usedChannelBits |= 1 << midiChannel_;
                     }
@@ -546,17 +547,14 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
 
 EXPORT s32 CC MIDI_PlayerPlayMidiNote_49DAD0(s32 vabId, s32 program, s32 note, s32 leftVol, s32 rightVol, s32 volume)
 {
-
-    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, rightVol, volume);
-
-    //if (rightVol >= 64)
-    //{
-    //    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol * (127 - rightVol) / 64, leftVol, volume);
-    //}
-    //else
-    //{
-    //    return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, leftVol * rightVol / 64, volume);
-    //}
+    if (rightVol >= 64)
+    {
+        return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol * (127 - rightVol) / 64, leftVol, volume);
+    }
+    else
+    {
+        return MIDI_PlayerPlayMidiNote_49D730(vabId, program, note, leftVol, leftVol * rightVol / 64, volume);
+    }
 }
 
 

--- a/Source/AliveLibAO/Midi.cpp
+++ b/Source/AliveLibAO/Midi.cpp
@@ -691,7 +691,7 @@ EXPORT s32 CC MIDI_ParseMidiMessage_49DD30(s32 idx)
                         auto r_vol = pProgVol->field_2_right_vol;
                         auto note = data.param1 << 8;
                         auto program = pProgVol->field_0_program;
-                        auto l_vol = pProgVol->field_1_left_vol; // (s16)((u32) (pProgVol->field_1_left_vol * pCtx->field_C_volume) >> 7);
+                        auto l_vol = (s16)((u32) (pProgVol->field_1_left_vol * pCtx->field_C_volume) >> 7);
 
                         auto freq = data.param2;
                         MIDI_PlayerPlayMidiNote_49DAD0(pCtx->field_seq_idx, program, note, l_vol, r_vol, freq); // Note: inlined

--- a/Source/AliveLibAO/Midi.cpp
+++ b/Source/AliveLibAO/Midi.cpp
@@ -511,13 +511,16 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
 
                         // Pan - L=0, C=64, R=127
                         s32 pan = 0;
-                        if (pVagOff->field_11_pad == 127)
+                        s32 maxPanVal = 9000;
+                        if (pVagOff->field_11_pad < 64)
                         {
-                            pan = 9000;
+                            double val = (pVagOff->field_11_pad / 64.0) * maxPanVal;
+                            pan = ((s32) val) - maxPanVal;
                         }
-                        else if (pVagOff->field_11_pad == 0)
+                        else if (pVagOff->field_11_pad > 64)
                         {
-                            pan = -9000;
+                            double val = ((128 - pVagOff->field_11_pad) / 64.0) * maxPanVal;
+                            pan = maxPanVal - ((s32) val);
                         }
 
                         SND_PlayEx_493040(

--- a/Source/AliveLibAO/Midi.hpp
+++ b/Source/AliveLibAO/Midi.hpp
@@ -195,7 +195,7 @@ EXPORT s16 CC SND_SEQ_Play_477760(SeqId idx, s32 repeatCount, s16 volLeft, s16 v
 
 EXPORT s16 CC SND_SsIsEos_DeInlined_477930(SeqId idx);
 
-EXPORT s32 CC SFX_SfxDefinition_Play_477330(const SfxDefinition* sfxDef, s16 volLeft, s16 volRight, s16 pitch_min, s16 pitch_max);
+EXPORT s32 CC SFX_SfxDefinition_Play_477330(const SfxDefinition* sfxDef, s16 volLeft, s16 volRight, s16 pitch_min, s16 pitch_max, s32 pan);
 
 EXPORT s32 CC SFX_SfxDefinition_Play_4770F0(const SfxDefinition* sfxDef, s32 vol, s32 pitch_min, s32 pitch_max);
 

--- a/Source/AliveLibAO/Movie.cpp
+++ b/Source/AliveLibAO/Movie.cpp
@@ -157,7 +157,7 @@ public:
                         SND_StopAll_4CB060();
 
                         bStartedPlayingSound = true;
-                        if (FAILED(GetSoundAPI().SND_PlayEx(&fmv_sound_entry, 116, 116, 1.0, 0, 1, 100)))
+                        if (FAILED(GetSoundAPI().SND_PlayEx(&fmv_sound_entry, 116, 116, 1.0, 0, 1, 100, 0)))
                         {
                             bNoAudioOrAudioError = 1;
                         }

--- a/Source/AliveLibAO/Paramite.cpp
+++ b/Source/AliveLibAO/Paramite.cpp
@@ -954,7 +954,7 @@ void Paramite::Sound_44DBB0(ParamiteSpeak idx)
             return;
     }
 
-    SFX_SfxDefinition_Play_477330(&stru_4CDD98[static_cast<s16>(idx)], volLeft, volRight, -520, -520);
+    SFX_SfxDefinition_Play_477330(&stru_4CDD98[static_cast<s16>(idx)], volLeft, volRight, -520, -520, 64);
 }
 
 void Paramite::SetMusic()

--- a/Source/AliveLibAO/Scrab.cpp
+++ b/Source/AliveLibAO/Scrab.cpp
@@ -838,7 +838,7 @@ s32 Scrab::Scrab_SFX_460B80(ScrabSounds soundId, s32 /*vol*/, s32 pitch, s16 app
                                          static_cast<s16>(volumeLeft),
                                          static_cast<s16>(volumeRight),
                                          static_cast<s16>(pitch),
-                                         static_cast<s16>(pitch));
+                                         static_cast<s16>(pitch), 64);
 }
 
 void Scrab::ToJump_45E340()

--- a/Source/AliveLibAO/Sfx.cpp
+++ b/Source/AliveLibAO/Sfx.cpp
@@ -163,7 +163,7 @@ s32 CC SFX_Play_43ADE0(SoundEffect sfxId, s32 leftVol, s32 rightVol, BaseAnimate
         right = static_cast<s16>(rightVol);
         left = static_cast<s16>(leftVol);
     }
-    return SFX_SfxDefinition_Play_477330(&sSfxEntries_4CCA38[sfxId], left, right, 0x7FFF, 0x7FFF);
+    return SFX_SfxDefinition_Play_477330(&sSfxEntries_4CCA38[sfxId], left, right, 0x7FFF, 0x7FFF, 64);
 }
 
 s32 CC SFX_Play_43AED0(SoundEffect sfxId, s32 volume, CameraPos direction)
@@ -186,7 +186,7 @@ s32 CC SFX_Play_43AED0(SoundEffect sfxId, s32 volume, CameraPos direction)
                 static_cast<s16>(2 * volume / 3),
                 static_cast<s16>(2 * volume / 9),
                 0x7FFF,
-                0x7FFF);
+                0x7FFF, 64);
         }
         case CameraPos::eCamRight_4:
         {
@@ -195,7 +195,7 @@ s32 CC SFX_Play_43AED0(SoundEffect sfxId, s32 volume, CameraPos direction)
                 static_cast<s16>(2 * volume / 9),
                 static_cast<s16>(2 * volume / 3),
                 0x7FFF,
-                0x7FFF);
+                0x7FFF, 64);
         }
         default:
         {

--- a/Source/AliveLibAO/Slig.cpp
+++ b/Source/AliveLibAO/Slig.cpp
@@ -240,6 +240,7 @@ void Slig::Slig_SoundEffect_46F310(SligSfx sfxIdx)
         volRight = sSligSounds_4CFB30[sfxIdxInt].field_C_default_volume / 2;
     }
     gMap_507BA8.Get_Camera_World_Rect_444C30(dir, &worldRect);
+    s32 pan = 64;
     switch (dir)
     {
         case CameraPos::eCamCurrent_0:
@@ -259,6 +260,11 @@ void Slig::Slig_SoundEffect_46F310(SligSfx sfxIdx)
             FP percentHowFar = (FP_FromInteger(worldRect.w) - field_A8_xpos) / FP_FromInteger(640);
             volLeft = volRight - FP_GetExponent(percentHowFar * FP_FromInteger(volRight - (volRight / 3)));
             volRight -= FP_GetExponent(percentHowFar * FP_FromInteger(volRight));
+          
+            double check = FP_GetDouble(percentHowFar);
+            double scale = 2 * (check - .22);
+            pan = ((s32) (64 - (scale * 64)));
+            pan = pan > 64 ? 64 : pan;
             break;
         }
         case CameraPos::eCamRight_4:
@@ -266,6 +272,11 @@ void Slig::Slig_SoundEffect_46F310(SligSfx sfxIdx)
             FP percentHowFar = (field_A8_xpos - FP_FromInteger(worldRect.x)) / FP_FromInteger(640);
             volLeft = volRight - FP_GetExponent(percentHowFar * FP_FromInteger(volRight));
             volRight -= FP_GetExponent(percentHowFar * FP_FromInteger(volRight - (volRight / 3)));
+
+            double check = FP_GetDouble(percentHowFar);
+            double scale = 2 * (check - .22);
+            pan = ((s32) (64 + (scale * 64)));
+            pan = pan < 64 ? 64 : pan;
             break;
         }
         default:
@@ -279,7 +290,7 @@ void Slig::Slig_SoundEffect_46F310(SligSfx sfxIdx)
     auto pitch = Math_RandomRange_450F20(
         sSligSounds_4CFB30[sfxIdxInt].field_E_pitch_min,
         sSligSounds_4CFB30[sfxIdxInt].field_E_pitch_min);
-    SFX_SfxDefinition_Play_477330(&sSligSounds_4CFB30[sfxIdxInt], static_cast<s16>(volLeft), static_cast<s16>(volRight), pitch, pitch);
+    SFX_SfxDefinition_Play_477330(&sSligSounds_4CFB30[sfxIdxInt], static_cast<s16>(volLeft), static_cast<s16>(volRight), pitch, pitch, pan);
 }
 
 Slig* Slig::ctor_464D40(Path_Slig* pTlv, s32 tlvInfo)

--- a/Source/AliveLibAO/Slog.cpp
+++ b/Source/AliveLibAO/Slog.cpp
@@ -848,7 +848,7 @@ void Slog::Sfx_475BD0(s32 soundId)
                                   static_cast<s16>(volumeLeft),
                                   static_cast<s16>(volumeRight),
                                   static_cast<s16>(sndDef.field_E_pitch_min),
-                                  static_cast<s16>(sndDef.field_10_pitch_max));
+                                  static_cast<s16>(sndDef.field_10_pitch_max), 64);
 }
 
 s16 Slog::IsPlayerNear_471930()


### PR DESCRIPTION
2 things done:

- These changes allow audio panning of audio sequences, most notable on the title tracks of both AO and AE. 
- I commented "wait until" logic around the sequence loop. It seems to have waited every 30ms before checking sequences. While it's only 30ms, audio sounded like it was racing or slowing down at times, i.e. off beat. I wonder if this check was originally to save CPU cycles, but I doubt it's an issue on new hardware.

There seemed to be extra logic with 64 (center) and 127 (right) values, I commented them out instead of removing them,  unsure how you want to handle it, for original reversing efforts. 

As a side note there was actually a comment in `PsxSpuApi.cpp` about assigning `field_3_pan` to `field_11_pad`. I'm tempted to change `field_11_pad` to `pan`.

Further, the change is duplicated for AO and AE, combining them would be too large of a change for this PR I think. Also, some of the values passed in places for left or right pan are unused now, so cleanup could be done. 