### PR TITLE
Audio panning attempt 2

### DIFF
--- a/Source/AliveLibAE/Sound/PsxSpuApi.cpp
+++ b/Source/AliveLibAE/Sound/PsxSpuApi.cpp
@@ -686,7 +686,9 @@ EXPORT s32 CC MIDI_PlayMidiNote_4FCB30(s32 vabId, s32 program, s32 note, s32 lef
                     {
                         MIDI_Wait_4FCE50();
                     }
-
+                    
+                    // reuse a field that is never accessed for passing the samples pan
+                    GetSpuApiVars()->sSoundEntryTable16().table[vabId][pVagIter->field_10_vag].field_1F = pVagIter->field_11_pad;
                     GetSoundAPI().SND_PlayEx(
                         &gSpuVars->sSoundEntryTable16().table[vabId][pVagIter->field_10_vag],
                         panLeft,

--- a/Source/AliveLibAO/Midi.cpp
+++ b/Source/AliveLibAO/Midi.cpp
@@ -507,7 +507,10 @@ EXPORT s32 CC MIDI_PlayerPlayMidiNote_49D730(s32 vabId, s32 program, s32 note, s
                         auto v29 = pVagOff->field_A_shift_cen;
                         pChannel->field_1C_adsr.field_2_note_byte1 = BYTE1(note) & 0x7F;
                         auto freq = pow(1.059463094359, (f64)(note - v29) * 0.00390625);
-                        pChannel->field_10_freq = (f32) freq;
+                        pChannel->field_10_freq = (f32) freq;                     
+
+                        // reuse a field that is never accessed for passing the samples pan
+                        GetSpuApiVars()->sSoundEntryTable16().table[vabId][vag_num].field_1F = pVagOff->field_11_pad;
                         SND_PlayEx_493040(
                             &GetSpuApiVars()->sSoundEntryTable16().table[vabId][vag_num],
                             panLeft,


### PR DESCRIPTION
- SFX panning can be fixed with just a change to `Sound.cpp`
- To fix music panning I passed the samples pan value from `PsxSpuApi.cpp` and `Midi.cpp` to `Sound.cpp` through a non-accessed field in `SoundEntry`. 