### PR TITLE
Ensure ids are always unique to fix #1223

### DIFF
--- a/Source/AliveLibAE/BaseGameObject.cpp
+++ b/Source/AliveLibAE/BaseGameObject.cpp
@@ -85,7 +85,7 @@ void BaseGameObject::BaseGameObject_ctor_4DBFA0(s16 bAddToObjectList, s16 resour
     field_8_object_id = nextId;
     sObjectIds_5C1B70.Insert_449C10(nextId, this);
 
-    sAccumulatedObjectCount_5C1BF4 = nextId++;
+    sAccumulatedObjectCount_5C1BF4 = ++nextId;
 }
 
 EXPORT void BaseGameObject::BaseGameObject_dtor_4DBEC0()

--- a/Source/AliveLibAE/BaseGameObject.cpp
+++ b/Source/AliveLibAE/BaseGameObject.cpp
@@ -80,10 +80,12 @@ void BaseGameObject::BaseGameObject_ctor_4DBFA0(s16 bAddToObjectList, s16 resour
         }
     }
 
-    field_C_objectId = sAccumulatedObjectCount_5C1BF4;
-    field_8_object_id = sAccumulatedObjectCount_5C1BF4;
-    const s32 nextId = sAccumulatedObjectCount_5C1BF4++;
+    s32 nextId = sObjectIds_5C1B70.EnsureIdIsUnique(sAccumulatedObjectCount_5C1BF4);
+    field_C_objectId = nextId;
+    field_8_object_id = nextId;
     sObjectIds_5C1B70.Insert_449C10(nextId, this);
+
+    sAccumulatedObjectCount_5C1BF4 = nextId++;
 }
 
 EXPORT void BaseGameObject::BaseGameObject_dtor_4DBEC0()

--- a/Source/AliveLibAE/ObjectIds.cpp
+++ b/Source/AliveLibAE/ObjectIds.cpp
@@ -154,6 +154,46 @@ BaseGameObject* ObjectIds::Find(TObjectId_KeyType idToFind, AETypes type)
     return pItem;
 }
 
+s32 ObjectIds::EnsureIdIsUnique(s32 nextId)
+{
+    ObjectId_Record* pRecord = field_4_pBuffer[Id_To_Buffer_Size_Range_449BA0(nextId)];
+
+    while (pRecord)
+    {
+        if (pRecord->field_0_id >= nextId) // We've found a value equal to or higher than the input id, to prevent duplicates we need to find the highest used ID and +1 that
+        {
+            return GetHighestUsedId() + 1;
+        }
+
+        // Go to the next record
+        pRecord = pRecord->field_8_pNext;
+    }
+
+    return nextId;
+}
+
+s32 ObjectIds::GetHighestUsedId()
+{
+    s32 nextId = 0;
+    for (u32 i = 0; i < field_0_buffer_size; i++)
+    {
+        ObjectId_Record* pRecord = field_4_pBuffer[i];
+
+        while (pRecord)
+        {
+            if (pRecord->field_0_id > nextId)
+            {
+                nextId = pRecord->field_0_id;
+            }
+
+            // Go to the next record
+            pRecord = pRecord->field_8_pNext;
+        }
+    }
+
+    return nextId;
+}
+
 #include <gmock/gmock.h>
 
 namespace AETest::TestsObjectIds {

--- a/Source/AliveLibAE/ObjectIds.hpp
+++ b/Source/AliveLibAE/ObjectIds.hpp
@@ -35,6 +35,8 @@ public:
 
 public:
     BaseGameObject* Find(TObjectId_KeyType idToFind, AETypes type);
+    s32 EnsureIdIsUnique(s32 nextId);
+    s32 GetHighestUsedId();
 
 private:
     u32 field_0_buffer_size;


### PR DESCRIPTION
Fixes #1223  AE OG Bug - The game sometimes gets the wrong type id when quicksaving/quickloading by ensuring that entity ids are unique.