### PR TITLE
Use log warning instead of `ALIVE_FATAL` in `vExitPortal`

### DIFF
--- a/Source/AliveLibAE/BirdPortal.cpp
+++ b/Source/AliveLibAE/BirdPortal.cpp
@@ -968,7 +968,7 @@ void BirdPortal::vExitPortal_499870()
     }
     else
     {
-        ALIVE_FATAL("Bird portal exit object not found!");
+        LOG_WARNING("Bird portal exit object not found!");
     }
 }
 

--- a/Source/AliveLibAO/BirdPortal.cpp
+++ b/Source/AliveLibAO/BirdPortal.cpp
@@ -1070,7 +1070,7 @@ void BirdPortal::VExitPortal_453720()
     }
     else
     {
-        ALIVE_FATAL("Bird portal exit object not found!");
+        LOG_WARNING("Bird portal exit object not found!");
     }
 }
 


### PR DESCRIPTION
apparently the AE game ender bird portal doesn't have a bird portal exit