### PR TITLE
Stops objects from leaking into the void by marking them as free if they existed prior to the loading

### DIFF
--- a/Scripts/refactor.py
+++ b/Scripts/refactor.py
@@ -137,11 +137,11 @@ virtual void VScreenChanged() override
     line = line.replace("LOBYTE(field_6_flags) |= 4u", "field_6_flags.Set(BaseGameObject::eDead_Bit3)")
 
     line = line.replace("1835626049", "ResourceManager::Resource_Animation")
-    line = line.replace("0x746C6150", "ResourceManager::Resource_Animation")
+    line = line.replace("0x6D696E41", "ResourceManager::Resource_Animation")
     line = line.replace("'minA'", "ResourceManager::Resource_Animation")
 
     line = line.replace("1953259856", "ResourceManager::Resource_Palt")
-    line = line.replace("0x6D696E41", "ResourceManager::Resource_Animation")
+    line = line.replace("0x746C6150", "ResourceManager::Resource_Palt")
     line = line.replace("'tlaP'", "ResourceManager::Resource_Palt")
 
 

--- a/Source/AliveLibAO/ResourceManager.cpp
+++ b/Source/AliveLibAO/ResourceManager.cpp
@@ -289,7 +289,7 @@ void CC ResourceManager::On_Loaded_446C10(ResourceManager_FileRecord* pLoaded)
 
     // pLoaded is done with now, remove it
     ObjList_5009E0->Remove_Item(pLoaded);
-
+    
     if (pLoaded)
     {
         // And destruct/free it
@@ -401,7 +401,7 @@ void CC ResourceManager::LoadResourcesFromList_446E80(const char_type* pFileName
     bool allResourcesLoaded = true;
     for (s32 i = 0; i < pTypeAndIdList->field_0_count; i++)
     {
-        while (!ResourceManager::GetLoadedResource_4554F0(
+        if (!ResourceManager::GetLoadedResource_4554F0(
             pTypeAndIdList->field_4_items[i].field_0_type,
             pTypeAndIdList->field_4_items[i].field_4_res_id,
             0,
@@ -791,7 +791,7 @@ EXPORT u8** CC ResourceManager::Allocate_New_Block_454FE0(u32 sizeBytes, BlockAl
 {
     ResourceHeapItem* pListItem = sFirstLinkedListItem_50EE2C;
     ResourceHeapItem* pHeapMem = nullptr;
-    const u32 size = (sizeBytes + 3) & ~3u; // Rounding ??
+    const u32 size = (sizeBytes + 3) & ~3u; // Align to a multiple of 4
     Header* pHeaderToUse = nullptr;
     while (pListItem)
     {
@@ -934,19 +934,26 @@ s16 CC ResourceManager::Move_Resources_To_DArray_455430(u8** ppRes, DynamicArray
 {
     auto pItemToAdd = (ResourceHeapItem*) ppRes;
     Header* pHeader = Get_Header_455620(ppRes);
+    u8** pFoundResourceInList = nullptr;
     if (pHeader->field_8_type != Resource_End)
     {
         while (pHeader->field_8_type != Resource_Pend
                && pHeader->field_0_size
                && !(pHeader->field_0_size & 3))
         {
-            if (pArray)
+            if (pFoundResourceInList) // If we already found it in the list already and incremented the ref count, so mark this as free
+            {
+                pHeader->field_8_type = Resource_Free;
+            }
+            else if (pArray)
             {
                 pArray->Push_Back((u8**) pItemToAdd);
                 pHeader->field_4_ref_count++;
             }
 
             pHeader = (Header*) ((s8*) pHeader + pHeader->field_0_size);
+               
+            pFoundResourceInList = GetLoadedResource_4554F0(pHeader->field_8_type, pHeader->field_C_id, 1, 0);
 
             // Out of heap space
             if (pHeader->field_0_size >= kResHeapSize)

--- a/Source/AliveLibAO/ResourceManager.hpp
+++ b/Source/AliveLibAO/ResourceManager.hpp
@@ -46,6 +46,8 @@ public:
         Resource_End = 0x21646E45,
         Resource_Plbk = 0x6B626C50,
         Resource_Play = 0x79616C50,
+        Resource_Indx = 0x78646E49,
+        Resource_Seq = 0x20716553,
     };
 
     enum ResourceHeaderFlags : s16

--- a/get_sdl2_win32.ps1
+++ b/get_sdl2_win32.ps1
@@ -11,7 +11,7 @@ If(!(test-path build\SDL2))
     Write-Host Creating build\SDL2
     New-Item -ItemType Directory -Force -Path build\SDL2
     Write-Host Download ZIP
-    Invoke-WebRequest -Uri 'https://www.libsdl.org/release/SDL2-devel-2.0.8-VC.zip' -OutFile 'build\SDL2.zip'
+    Invoke-WebRequest -Uri 'https://www.libsdl.org/release/SDL2-devel-2.0.22-VC.zip' -OutFile 'build\SDL2.zip'
     Write-Host Extract zip
     Unzip "build\SDL2.zip" "build\SDL2"
 }


### PR DESCRIPTION
Should grant the player the ability to play through the entire game in 1 sitting(allegedly, I am not good enough at the game to perform this myself), based monitoring the heap data. No more leaky objects. Also corrects a mistake in refactor.py and updates get_sdl_win32.ps1 to the latest required version.

WARNING: MIGHT (WILL?) BREAK EXISTING PLAYBACKS IN SOME PLACES(seems to be related to the LoadingFile entity)