### PR TITLE
bump appveyor image to Visual Studio 2022

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 
-image: Visual Studio 2017
+image: Visual Studio 2022
 
 platform: 
  - x86
@@ -16,8 +16,8 @@ build_script:
  - cd build
  - echo %platform%
  - echo %APPVEYOR_BUILD_NUMBER%
- - if %platform%==x64 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 15 2017 Win64")
- - if %platform%==x86 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 15 2017")
+ - if %platform%==x64 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 17 2022 Win64")
+ - if %platform%==x86 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 17 2022")
  - cmake --build . --config %configuration% -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
  - call "C:\Program Files (x86)\cmake\bin\cpack" -G ZIP -C %configuration%
  - ctest
@@ -43,4 +43,4 @@ artifacts:
  - path: build\RELIVE_Windows_Binaries_Lite_*.zip
    name: RELIVE_Windows_Binaries_$(configuration)_$(PLATFORM)
 
-test: off
+test: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,8 @@ build_script:
  - cd build
  - echo %platform%
  - echo %APPVEYOR_BUILD_NUMBER%
- - if %platform%==x64 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 17 2022 Win64")
- - if %platform%==x86 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 17 2022")
+ - if %platform%==x64 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 17 2022" -A x64)
+ - if %platform%==x86 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 17 2022" -A Win32)
  - cmake --build . --config %configuration% -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
  - cpack -G ZIP -C %configuration%
  - ctest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
  - if %platform%==x64 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 17 2022 Win64")
  - if %platform%==x86 (cmake .. -DSDL2_DIR=c:\relive\SDL2-2.0.22 -DBUILD_NUMBER=%APPVEYOR_BUILD_NUMBER% -DCI_PROVIDER=AppVeyor -G "Visual Studio 17 2022")
  - cmake --build . --config %configuration% -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
- - call "C:\Program Files (x86)\cmake\bin\cpack" -G ZIP -C %configuration%
+ - cpack -G ZIP -C %configuration%
  - ctest
 
 install:


### PR DESCRIPTION
hopefully resolves crazy audio stuttering for appveyor builds. this seems to mainly happen on appveyor builds and it appears to be fine on azure builds. the only difference i could spot is that appveyor was using `Visual Studio 15 2017` while azure is using a slightly more up to date version `Visual Studio 16 2019`.