### PR TITLE
Windows 10 cmake build issues

### DIFF
--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -56,18 +56,16 @@ add_library(googletest
     )
 
 target_include_directories(googletest SYSTEM PUBLIC
-    $<BUILD_INTERFACE:
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest;
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest/include;
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest/include/gtest;
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest/include/gtest/internal;
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock;
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include;
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include/gmock;
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include/gmock/internal;
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include/gmock/internal/custom>
-    $<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include/gmock>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest/include/gtest>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest/include/gtest/internal>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include/gmock>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include/gmock/internal>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include/gmock/internal/custom>"
+    "$<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock/include/gmock>"
     )
 
 export(TARGETS googletest FILE googletest.cmake)
@@ -89,9 +87,8 @@ target_link_libraries(imgui
     )
 
 target_include_directories(imgui SYSTEM PUBLIC
-    $<BUILD_INTERFACE:
-    ${CMAKE_CURRENT_SOURCE_DIR}/imgui;
-    ${CMAKE_CURRENT_SOURCE_DIR}/imgui/backends>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/imgui>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/imgui/backends>"
     )
 add_compile_definitions(IMGUI_IMPL_OPENGL_LOADER_GLEW)
 export(TARGETS imgui FILE imgui.cmake)
@@ -106,8 +103,7 @@ export(TARGETS libglew_static FILE libglew_static.cmake)
 add_library(glm INTERFACE)
 
 target_include_directories(glm SYSTEM INTERFACE
-    $<BUILD_INTERFACE:
-    ${CMAKE_CURRENT_SOURCE_DIR}/glm>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/glm>"
     )
 export(TARGETS glm FILE glm.cmake)
 
@@ -118,9 +114,8 @@ add_library(miniz
     )
 
 target_include_directories(miniz SYSTEM PUBLIC
-    $<BUILD_INTERFACE:
-    ${CMAKE_CURRENT_SOURCE_DIR}/miniz;
-    $<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/miniz>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/miniz>"
+    "$<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/miniz>"
     )
 
 export(TARGETS miniz FILE miniz.cmake)
@@ -133,9 +128,8 @@ add_library(miniz_dynamic_crt
     )
 
 target_include_directories(miniz_dynamic_crt SYSTEM PUBLIC
-    $<BUILD_INTERFACE:
-    ${CMAKE_CURRENT_SOURCE_DIR}/miniz;
-    $<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/miniz>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/miniz>"
+    "$<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/miniz>"
     )
 if (MSVC)
     target_compile_options(miniz_dynamic_crt PRIVATE /MDd)
@@ -155,10 +149,9 @@ target_compile_definitions(spng PRIVATE SPNG_STATIC)
 target_compile_definitions(spng PUBLIC SPNG_STATIC)
 
 target_include_directories(spng SYSTEM PUBLIC
-    $<BUILD_INTERFACE:
-    ${CMAKE_CURRENT_SOURCE_DIR}/libspng;
-    ${CMAKE_CURRENT_SOURCE_DIR}/miniz;
-    $<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libspng>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libspng>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/miniz>"
+    "$<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libspng>"
     )
 
 export(TARGETS spng FILE spng.cmake)
@@ -175,10 +168,9 @@ target_compile_definitions(spng_dynamic_crt PRIVATE SPNG_STATIC)
 target_compile_definitions(spng_dynamic_crt PUBLIC SPNG_STATIC)
 
 target_include_directories(spng_dynamic_crt SYSTEM PUBLIC
-    $<BUILD_INTERFACE:
-    ${CMAKE_CURRENT_SOURCE_DIR}/libspng;
-    ${CMAKE_CURRENT_SOURCE_DIR}/miniz;
-    $<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libspng>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libspng>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/miniz>"
+    "$<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libspng>"
     )
 if (MSVC)
     target_compile_options(spng_dynamic_crt PRIVATE /MDd)

--- a/Source/Tools/relive_api/CMakeLists.txt
+++ b/Source/Tools/relive_api/CMakeLists.txt
@@ -74,11 +74,11 @@ if (MSVC)
 endif()
 
 target_include_directories(relive_api PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/../../../3rdParty/EasyLogging++/EasyLogging/src
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/../../../3rdParty/googletest/googlemock/include
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/../../../3rdParty/googletest/googletest/include
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/../../../3rdParty
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/../../../3rdParty/json/include
-    $<INSTALL_INTERFACE:include>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty/EasyLogging++/EasyLogging/src>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty/googletest/googlemock/include>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty/googletest/googletest/include>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty/json/include>"
+    "$<INSTALL_INTERFACE:include>"
     PRIVATE ${CMAKE_BINARY_DIR})

--- a/Source/relive_lib/CMakeLists.txt
+++ b/Source/relive_lib/CMakeLists.txt
@@ -734,14 +734,13 @@ target_link_libraries(relive_lib Rpcrt4)
 endif()
 
 target_include_directories(relive_lib PUBLIC
-    $<BUILD_INTERFACE:
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty/aom
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty/aom/third_party/libwebm
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty/json/single_include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty/DX9_SDK_Aug09/Include>
-    $<INSTALL_INTERFACE:include>
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty/aom>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty/aom/third_party/libwebm>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty/json/single_include>"
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/3rdParty/DX9_SDK_Aug09/Include>"
+    "$<INSTALL_INTERFACE:include>"
     PRIVATE src ${CMAKE_BINARY_DIR})
 
 target_compile_definitions(relive_lib PRIVATE "_CRT_SECURE_NO_WARNINGS")


### PR DESCRIPTION
Using:

Windows 10 64bit
VisualStudio 2022
cmake 3.29.6

The cmake build was failing with error
`Error: CMake file API parsing response files failed. Check for invalid paths in your CMakeLists.txt files. Parsing failed when attempting to parse this path: "C:\\Users\\[...]\\alive_reversing\\3rdParty\\$<BUILD_INTERFACE:"`

I put each line in quotes and put `$<BUILD_INTERFACE` in front of each line, it seems to be working ok now. 

I had also seen it generating some paths with new line characters, like `\\path1\n    \\path2`

Not sure if this would have negative impacts on other platforms. 