### PR TITLE
Fix for memory exhaustion in GL renderer when minimised

### DIFF
--- a/Source/relive_lib/Renderer/OpenGL3/OpenGLRenderer.cpp
+++ b/Source/relive_lib/Renderer/OpenGL3/OpenGLRenderer.cpp
@@ -123,16 +123,17 @@ void OpenGLRenderer::StartFrame()
 {
     IRenderer::StartFrame();
 
+    // Always reset stats and batcher states so we do not build up memory
+    // if the window is minimized
+    mStats.Reset();
+    mBatcher.StartFrame();
+
     if (SDL_GetWindowFlags(mWindow) & SDL_WINDOW_MINIMIZED)
     {
         return;
     }
 
-    mStats.Reset();
-
     mFrameStarted = true;
-
-    mBatcher.StartFrame();
 
     // Set offsets for the screen (this is for the screen shake effect)
     mOffsetX = 0;


### PR DESCRIPTION
Per title - solution is to move the stats/batcher reset above the early return in `StartFrame`.