### PR TITLE
Fixes #1667: bump cmake version requirement to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(relive VERSION 0.1 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/options.cmake
+++ b/options.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 option(RENDER_TEST "Create test object that renders all prim types on boot" OFF)
 option(DEVELOPER_MODE "Boot direct to main selection screen, enable debug.sav loading" OFF)


### PR DESCRIPTION
Version requirement bump so that CMake >= 4.0 is happy again.