### PR TITLE
Fix SligSpawner chase_abe_when_spotted type in AE relive_api

### DIFF
--- a/Source/Tools/relive_api/JsonUpgraderAE.cpp
+++ b/Source/Tools/relive_api/JsonUpgraderAE.cpp
@@ -35,8 +35,24 @@ public:
     }
 };
 
+class UpgraderAE4 final : public IJsonUpgrader
+{
+public:
+    std::string Upgrade(JsonUpgraderBase& upgrader, nlohmann::basic_json<>& rootObj) override
+    {
+        const RemapEnums directionToChoice =
+        {
+             {"Left", "No"},
+             {"Right", "Yes"}
+        };
+        upgrader.RemapMapObjectPropertyValues(rootObj, "SligSpawner", "Chase Abe When Spotted", directionToChoice);
+        return rootObj.dump(4);
+    }
+};
+
 void JsonUpgraderAE::AddUpgraders()
 {
     ADD_UPGRADE_STEP_FROM(3, UpgraderAE3);
+    ADD_UPGRADE_STEP_FROM(4, UpgraderAE4);
 }
 } // namespace ReliveAPI

--- a/Source/Tools/relive_api/TlvsAE.hpp
+++ b/Source/Tools/relive_api/TlvsAE.hpp
@@ -223,7 +223,7 @@ struct Path_SligSpawner final : public Path_TLV
     s16 unknown; // maybe number of times to shoot after spawning?
     s16 code_1;
     s16 code_2;
-    XDirection_short chase_abe_when_spotted;
+    Choice_short chase_abe_when_spotted;
     XDirection_short start_direction;
     s16 panic_timeout;
     s16 num_panic_sounds;

--- a/Source/Tools/relive_api/relive_api.cpp
+++ b/Source/Tools/relive_api/relive_api.cpp
@@ -256,7 +256,7 @@ enum class OpenPathBndResult
 
 // Increment when a breaking change to the JSON is made and implement an
 // upgrade step that converts from the last version to the current.
-constexpr s32 kApiVersion = 4;
+constexpr s32 kApiVersion = 5;
 
 [[nodiscard]] s32 GetApiVersion()
 {


### PR DESCRIPTION
## Summary
`Path_SligSpawner` declares `chase_abe_when_spotted` as `XDirection_short`, but the field is a boolean. This changes it to `Choice_short`, matching every other declaration of the same field.

Context: `chase_abe_when_spotted` (AO: `field_32_chase_abe`) is `Choice_short` everywhere else and `Path_SligSpawner` in AE is the only outlier.

Consequence if not fixed: the field would offer Left/Right instead of a yes/no choice in the relive_api editor.
