### PR TITLE
Fix MovieHandstone field order in AE relive_api

### DIFF
--- a/Source/Tools/relive_api/TlvsAE.hpp
+++ b/Source/Tools/relive_api/TlvsAE.hpp
@@ -167,10 +167,9 @@ struct Path_SligGetPants final : public Path_TLV
 
 struct Path_MovieHandstone final : public Path_TLV
 {
-    s16 padding;
-    Scale_short scale;
     s16 movie_number;
-    s16 trigger_switch_id;
+    Scale_short scale;
+    s32 trigger_switch_id;
 };
 
 struct Path_CreditsController final : public Path_TLV
@@ -1697,10 +1696,9 @@ struct Path_MovieHandstone final : public ReliveAPI::TlvObjectBaseAE
 {
     CTOR_AE(Path_MovieHandstone, "MovieHandstone", TlvTypes::MovieHandStone_27)
     {
-        ADD("Scale", mTlv.scale);
         ADD("Movie Number", mTlv.movie_number);
+        ADD("Scale", mTlv.scale);
         ADD("Trigger Switch ID", mTlv.trigger_switch_id);
-        ADD("Padding", mTlv.padding);
     }
 };
 


### PR DESCRIPTION
## Summary
`Path_MovieHandstone` in TlvsAE.hpp doesn't match what the engine reads.
`Path_MovieStone` (AliveLibAE/Path.hpp, sizeof-checked at 0x18) lays the payload out as movie number (word 0), scale (word 1), then one **s32** trigger switch id (words 2-3), and `Abe.cpp` reads `field_10_movie_number` as the FMV id.

The API struct had `padding` first and `movie_number` third, and the CTOR bound a third order again (Scale, Movie Number, Trigger, Padding), so every parsed stone came out with its film number in `Scale` and its scale in `Movie Number`.

The five stones Exoddus ships show it directly: parsed with the old layout they read `Scale` = 3/2/4/4/14 (film numbers) and `Movie Number` = 0 on all five.

This is a parse-layer fix only (no API version bump and no upgrade step), per the bundle-changes guidance:
- The JSON property names don't change, so the schema is untouched.
- An old file's orphaned `Padding` key is ignored on read (`PropertiesFromJson` iterates declared properties only).
- The one value an upgrader might want to restore, the movie number, is unrecoverable from old exports anyway: the film number sat in a `Scale_short` enum, and out-of-range enum values collapse to the first registered name at export.

## Downstream
https://oddworldmap.com derives its object layouts from these CTOR blocks, and arrived at the same reading from the opposite direction: the extracted stones were the implausible ones, and `Path_MovieStone` explained why. It carries a local correction until this lands (https://github.com/MagogCartel/OddworldMap/commit/4c4a43074ae475b5b7eb015f0df4dbf66c7574da), keyed to the layout the CTOR yields today so that merging this fix fails the workaround loudly rather than silently double-correcting the stone.
